### PR TITLE
Feature/external api add background image

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,4 +20,4 @@
 
 ## Issues to clarify before merge
 
-- [ ] : Issue
+- [ ] Issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2021-03-19
+## Added
+- Adding an external endpoint to add a background image/color to the room
+
 ## [1.0.3] - 2021-03-19
 ### Fixed
 - Correction about which files should be packaged in the release.
@@ -11,9 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.2] - 2021-03-19
 ### Fixed
 - ivicos-release does not trigger CI pipeline for PRs
-
-## Added
-- Adding an external endpoint to add a background image/color to the room
 
 ## [1.0.1] - 2021-03-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - ivicos-release does not trigger CI pipeline for PRs
 
+## Added
+- Adding an external endpoint to add a background image/color to the room
+
 ## [1.0.1] - 2021-03-19
 ### Changed
 - Debian Changelog not regenerated for every version but just keeping the last version

--- a/conference.js
+++ b/conference.js
@@ -2924,7 +2924,17 @@ export default {
      * @param {Function} listener the listener.
      */
     setBackgroundImage(backgroundImageUrl, backgroundColor) {
-        const id = getLocalParticipant(APP.store.getState());
+        const state = APP.store.getState();
+        const id = getLocalParticipant(state);
+        const oldBackgroundState = state['features/room-background'];
+
+        if (
+            backgroundColor === oldBackgroundState.backgroundColor
+            && backgroundImageUrl === oldBackgroundState.backgroundImageUrl
+        ) {
+            return;
+        }
+
         const updateDate = Date.now();
         const backgroundData = `${updateDate}|${backgroundColor}|${backgroundImageUrl}`;
 

--- a/conference.js
+++ b/conference.js
@@ -2923,11 +2923,11 @@ export default {
     setBackgroundImage(backgroundImageUrl, backgroundColor) {
         const state = APP.store.getState();
         const localParticipant = getLocalParticipant(state);
-
         const backgroundData = `${backgroundColor}|${backgroundImageUrl}`;
 
         if (
-            backgroundData === localParticipant.backgroundData
+            !state['features/base/conference']?.conference
+            || backgroundData === localParticipant?.backgroundData
         ) {
             return;
         }

--- a/conference.js
+++ b/conference.js
@@ -2920,14 +2920,10 @@ export default {
         APP.store.dispatch(participantUpdated({
             id,
             local: true,
-            backgroundImageUrl,
-            backgroundColor,
-            backgroundLastUpdate: updateDate
+            backgroundData: `${updateDate}|${backgroundColor}|${backgroundImageUrl}`
         }));
         APP.store.dispatch(updateSettings({
-            backgroundImageUrl,
-            backgroundColor,
-            backgroundLastUpdate: updateDate
+            backgroundData: `${updateDate}|${backgroundColor}|${backgroundImageUrl}`
         }));
     },
 

--- a/conference.js
+++ b/conference.js
@@ -2940,10 +2940,8 @@ export default {
 
         // Update local participants background information
         APP.store.dispatch(participantUpdated({
-            localParticipant,
-            backgroundData
-        }));
-        APP.store.dispatch(updateSettings({
+            id: localParticipant.id,
+            local: localParticipant.local,
             backgroundData
         }));
 

--- a/conference.js
+++ b/conference.js
@@ -2925,7 +2925,7 @@ export default {
      */
     setBackgroundImage(backgroundImageUrl, backgroundColor) {
         const state = APP.store.getState();
-        const id = getLocalParticipant(state);
+        const localParticipant = getLocalParticipant(state);
         const oldBackgroundState = state['features/room-background'];
 
         if (
@@ -2940,7 +2940,7 @@ export default {
 
         // Update local participants background information
         APP.store.dispatch(participantUpdated({
-            id,
+            localParticipant,
             backgroundData
         }));
         APP.store.dispatch(updateSettings({
@@ -2949,6 +2949,15 @@ export default {
 
         // Update the room-background feature to update the background properties
         APP.store.dispatch(updateBackgroundData(backgroundData));
+
+        // Send a notification mentioning that the backgroundData is being set to the desired value
+        APP.API.notifyBackgroundChanged(
+            localParticipant.id,
+            localParticipant.id,
+            {
+                backgroundImageUrl,
+                backgroundColor
+            });
     },
 
     /**

--- a/conference.js
+++ b/conference.js
@@ -2913,6 +2913,23 @@ export default {
     removeListener(eventName, listener) {
         eventEmitter.removeListener(eventName, listener);
     },
+    setBackgroundImage(backgroundImageUrl, backgroundColor) {
+        const id = getLocalParticipant(APP.store.getState());
+        const updateDate = Date.now();
+
+        APP.store.dispatch(participantUpdated({
+            id,
+            local: true,
+            backgroundImageUrl,
+            backgroundColor,
+            backgroundLastUpdate: updateDate
+        }));
+        APP.store.dispatch(updateSettings({
+            backgroundImageUrl,
+            backgroundColor,
+            backgroundLastUpdate: updateDate
+        }));
+    },
 
     /**
      * Changes the display name for the local user

--- a/conference.js
+++ b/conference.js
@@ -125,9 +125,6 @@ import {
     makePrecallTest
 } from './react/features/prejoin';
 import { disableReceiver, stopReceiver } from './react/features/remote-control';
-import {
-    updateBackgroundData
-} from './react/features/room-background';
 import { toggleScreenshotCaptureEffect } from './react/features/screenshot-capture';
 import { setSharedVideoStatus } from './react/features/shared-video/actions';
 import { AudioMixerEffect } from './react/features/stream-effects/audio-mixer/AudioMixerEffect';
@@ -2926,17 +2923,14 @@ export default {
     setBackgroundImage(backgroundImageUrl, backgroundColor) {
         const state = APP.store.getState();
         const localParticipant = getLocalParticipant(state);
-        const oldBackgroundState = state['features/room-background'];
+
+        const backgroundData = `${backgroundColor}|${backgroundImageUrl}`;
 
         if (
-            backgroundColor === oldBackgroundState.backgroundColor
-            && backgroundImageUrl === oldBackgroundState.backgroundImageUrl
+            backgroundData === localParticipant.backgroundData
         ) {
             return;
         }
-
-        const updateDate = Date.now();
-        const backgroundData = `${updateDate}|${backgroundColor}|${backgroundImageUrl}`;
 
         // Update local participants background information
         APP.store.dispatch(participantUpdated({
@@ -2944,18 +2938,6 @@ export default {
             local: localParticipant.local,
             backgroundData
         }));
-
-        // Update the room-background feature to update the background properties
-        APP.store.dispatch(updateBackgroundData(backgroundData));
-
-        // Send a notification mentioning that the backgroundData is being set to the desired value
-        APP.API.notifyBackgroundChanged(
-            localParticipant.id,
-            localParticipant.id,
-            {
-                backgroundImageUrl,
-                backgroundColor
-            });
     },
 
     /**

--- a/conference.js
+++ b/conference.js
@@ -125,6 +125,9 @@ import {
     makePrecallTest
 } from './react/features/prejoin';
 import { disableReceiver, stopReceiver } from './react/features/remote-control';
+import {
+    updateBackgroundData
+} from './react/features/room-background';
 import { toggleScreenshotCaptureEffect } from './react/features/screenshot-capture';
 import { setSharedVideoStatus } from './react/features/shared-video/actions';
 import { AudioMixerEffect } from './react/features/stream-effects/audio-mixer/AudioMixerEffect';
@@ -2913,18 +2916,29 @@ export default {
     removeListener(eventName, listener) {
         eventEmitter.removeListener(eventName, listener);
     },
+
+    /**
+     * Set background image/color for the room.
+     * @param {String} backgroundImageUrl optional image URL for the background
+     * @param {String} backgroundColor optional color for the background
+     * @param {Function} listener the listener.
+     */
     setBackgroundImage(backgroundImageUrl, backgroundColor) {
         const id = getLocalParticipant(APP.store.getState());
         const updateDate = Date.now();
+        const backgroundData = `${updateDate}|${backgroundColor}|${backgroundImageUrl}`;
 
+        // Update local participants background information
         APP.store.dispatch(participantUpdated({
             id,
-            local: true,
-            backgroundData: `${updateDate}|${backgroundColor}|${backgroundImageUrl}`
+            backgroundData
         }));
         APP.store.dispatch(updateSettings({
-            backgroundData: `${updateDate}|${backgroundColor}|${backgroundImageUrl}`
+            backgroundData
         }));
+
+        // Update the room-background feature to update the background properties
+        APP.store.dispatch(updateBackgroundData(backgroundData));
     },
 
     /**

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1121,17 +1121,15 @@ class API {
     /**
      * Notify external application (if API is enabled) that user updated its background information.
      *
-     * @param {string} updaterId - Updater ID.
      * @param {string} localId - Local participant ID.
      * @param {Object} backgroundData - Background image/color object.
      * @returns {void}
      */
-    notifyBackgroundChanged(updaterId: string, localId: string, backgroundData: Object) {
+    notifyBackgroundChanged(localId: string, backgroundData: Object) {
         this._sendEvent({
             name: 'room-background-updated',
             backgroundData,
-            localId,
-            updaterId
+            localId
         });
     }
 

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -2,10 +2,7 @@
 
 import Logger from 'jitsi-meet-logger';
 
-import {
-    createApiEvent,
-    sendAnalytics
-} from '../../react/features/analytics';
+import { createApiEvent, sendAnalytics } from '../../react/features/analytics';
 import {
     getCurrentConference,
     sendTones,
@@ -14,14 +11,18 @@ import {
 } from '../../react/features/base/conference';
 import { overwriteConfig, getWhitelistedJSON } from '../../react/features/base/config';
 import { parseJWTFromURLParams } from '../../react/features/base/jwt';
-import JitsiMeetJS, { JitsiRecordingConstants } from '../../react/features/base/lib-jitsi-meet';
+import JitsiMeetJS, {
+    JitsiRecordingConstants
+} from '../../react/features/base/lib-jitsi-meet';
 import { MEDIA_TYPE } from '../../react/features/base/media';
-import { pinParticipant, getParticipantById, kickParticipant } from '../../react/features/base/participants';
+import {
+    pinParticipant,
+    getParticipantById,
+    kickParticipant
+} from '../../react/features/base/participants';
 import { setPrivateMessageRecipient } from '../../react/features/chat/actions';
 import { openChat } from '../../react/features/chat/actions.web';
-import {
-    processExternalDeviceRequest
-} from '../../react/features/device-selection/functions';
+import { processExternalDeviceRequest } from '../../react/features/device-selection/functions';
 import { isEnabled as isDropboxEnabled } from '../../react/features/dropbox';
 import { toggleE2EE } from '../../react/features/e2ee/actions';
 import { invite } from '../../react/features/invite';
@@ -85,7 +86,9 @@ function initCommands() {
             const muteMediaType = mediaType ? mediaType : MEDIA_TYPE.AUDIO;
 
             sendAnalytics(createApiEvent('muted-everyone'));
-            const participants = APP.store.getState()['features/base/participants'];
+            const participants = APP.store.getState()[
+                'features/base/participants'
+            ];
             const localIds = participants
                 .filter(participant => participant.local)
                 .filter(participant => participant.role === 'moderator')
@@ -97,25 +100,24 @@ function initCommands() {
             APP.store.dispatch(toggleLobbyMode(isLobbyEnabled));
         },
         'password': password => {
-            const { conference, passwordRequired }
-                = APP.store.getState()['features/base/conference'];
+            const { conference, passwordRequired } = APP.store.getState()[
+                'features/base/conference'
+            ];
 
             if (passwordRequired) {
                 sendAnalytics(createApiEvent('submit.password'));
 
-                APP.store.dispatch(setPassword(
-                    passwordRequired,
-                    passwordRequired.join,
-                    password
-                ));
+                APP.store.dispatch(
+                    setPassword(
+                        passwordRequired,
+                        passwordRequired.join,
+                        password
+                    )
+                );
             } else {
                 sendAnalytics(createApiEvent('password.changed'));
 
-                APP.store.dispatch(setPassword(
-                    conference,
-                    conference.lock,
-                    password
-                ));
+                APP.store.dispatch(setPassword(conference, conference.lock, password));
             }
         },
         'pin-participant': id => {
@@ -135,6 +137,25 @@ function initCommands() {
             const { duration, tones, pause } = options;
 
             APP.store.dispatch(sendTones(tones, duration, pause));
+        },
+        'set-background-image': (backgroundImageUrl, backgroundColor) => {
+            const state = APP.store.getState();
+
+            console.log('general state : ');
+            console.log(state);
+            const participants = APP.store.getState()[
+                'features/base/participants'
+            ];
+
+            console.log('Participants state : ');
+            console.log(participants);
+            const conference = APP.store.getState()[
+                'features/base/conference'
+            ];
+
+            console.log('Conference state : ');
+            console.log(conference);
+            APP.conference.setBackgroundImage(backgroundImageUrl, backgroundColor);
         },
         'set-large-video-participant': participantId => {
             logger.debug('Set large video participant command received');
@@ -256,13 +277,20 @@ function initCommands() {
             }
 
             if (dropboxToken && !isDropboxEnabled(state)) {
-                logger.error('Failed starting recording: dropbox is not enabled on this deployment');
+                logger.error(
+                    'Failed starting recording: dropbox is not enabled on this deployment'
+                );
 
                 return;
             }
 
-            if (mode === JitsiRecordingConstants.mode.STREAM && !(youtubeStreamKey || rtmpStreamKey)) {
-                logger.error('Failed starting recording: missing youtube or RTMP stream key');
+            if (
+                mode === JitsiRecordingConstants.mode.STREAM
+                && !(youtubeStreamKey || rtmpStreamKey)
+            ) {
+                logger.error(
+                    'Failed starting recording: missing youtube or RTMP stream key'
+                );
 
                 return;
             }
@@ -277,7 +305,7 @@ function initCommands() {
                             'file_recording_metadata': {
                                 'upload_credentials': {
                                     'service_name': RECORDING_TYPES.DROPBOX,
-                                    'token': dropboxToken
+                                    token: dropboxToken
                                 }
                             }
                         })
@@ -287,7 +315,7 @@ function initCommands() {
                         mode: JitsiRecordingConstants.mode.FILE,
                         appData: JSON.stringify({
                             'file_recording_metadata': {
-                                'share': shouldShare
+                                share: shouldShare
                             }
                         })
                     };
@@ -323,7 +351,12 @@ function initCommands() {
                 return;
             }
 
-            if (![ JitsiRecordingConstants.mode.FILE, JitsiRecordingConstants.mode.STREAM ].includes(mode)) {
+            if (
+                ![
+                    JitsiRecordingConstants.mode.FILE,
+                    JitsiRecordingConstants.mode.STREAM
+                ].includes(mode)
+            ) {
                 logger.error('Invalid recording mode provided!');
 
                 return;
@@ -349,7 +382,9 @@ function initCommands() {
                 }
                 APP.store.dispatch(openChat(participant));
             } else {
-                logger.error('No participant found for the given participantId');
+                logger.error(
+                    'No participant found for the given participantId'
+                );
             }
         },
         'cancel-private-chat': () => {
@@ -383,20 +418,21 @@ function initCommands() {
         const { name } = request;
 
         switch (name) {
-        case 'capture-largevideo-screenshot' :
-            APP.store.dispatch(captureLargeVideoScreenshot())
-                .then(dataURL => {
-                    let error;
+        case 'capture-largevideo-screenshot':
+            APP.store
+                    .dispatch(captureLargeVideoScreenshot())
+                    .then(dataURL => {
+                        let error;
 
-                    if (!dataURL) {
-                        error = new Error('No large video found!');
-                    }
+                        if (!dataURL) {
+                            error = new Error('No large video found!');
+                        }
 
-                    callback({
-                        error,
-                        dataURL
+                        callback({
+                            error,
+                            dataURL
+                        });
                     });
-                });
             break;
         case 'invite': {
             const { invitees } = request;
@@ -411,23 +447,23 @@ function initCommands() {
 
             // The store should be already available because API.init is called
             // on appWillMount action.
-            APP.store.dispatch(
-                invite(invitees, true))
-                .then(failedInvitees => {
-                    let error;
-                    let result;
+            APP.store
+                    .dispatch(invite(invitees, true))
+                    .then(failedInvitees => {
+                        let error;
+                        let result;
 
-                    if (failedInvitees.length) {
-                        error = new Error('One or more invites failed!');
-                    } else {
-                        result = true;
-                    }
+                        if (failedInvitees.length) {
+                            error = new Error('One or more invites failed!');
+                        } else {
+                            result = true;
+                        }
 
-                    callback({
-                        error,
-                        result
+                        callback({
+                            error,
+                            result
+                        });
                     });
-                });
             break;
         }
         case 'is-audio-muted':
@@ -447,7 +483,9 @@ function initCommands() {
             break;
         case 'get-content-sharing-participants': {
             const tracks = getState()['features/base/tracks'];
-            const sharingParticipantIds = tracks.filter(tr => tr.videoType === 'desktop').map(t => t.participantId);
+            const sharingParticipantIds = tracks
+                    .filter(tr => tr.videoType === 'desktop')
+                    .map(t => t.participantId);
 
             callback({
                 sharingParticipantIds
@@ -460,7 +498,10 @@ function initCommands() {
             let livestreamUrl;
 
             if (conference) {
-                const activeSession = getActiveSession(state, JitsiRecordingConstants.mode.STREAM);
+                const activeSession = getActiveSession(
+                        state,
+                        JitsiRecordingConstants.mode.STREAM
+                );
 
                 livestreamUrl = activeSession?.liveStreamViewURL;
             } else {
@@ -488,12 +529,13 @@ function shouldBeEnabled() {
     return (
         typeof API_ID === 'number'
 
-            // XXX Enable the API when a JSON Web Token (JWT) is specified in
-            // the location/URL because then it is very likely that the Jitsi
-            // Meet (Web) app is being used by an external/wrapping (Web) app
-            // and, consequently, the latter will need to communicate with the
-            // former. (The described logic is merely a heuristic though.)
-            || parseJWTFromURLParams());
+        // XXX Enable the API when a JSON Web Token (JWT) is specified in
+        // the location/URL because then it is very likely that the Jitsi
+        // Meet (Web) app is being used by an external/wrapping (Web) app
+        // and, consequently, the latter will need to communicate with the
+        // former. (The described logic is merely a heuristic though.)
+        || parseJWTFromURLParams()
+    );
 }
 
 /**
@@ -636,10 +678,19 @@ class API {
      * @param {Object} options - Object with the message properties.
      * @returns {void}
      */
-    notifyReceivedChatMessage(
-            { body, id, nick, privateMessage, ts }: {
-                body: *, id: string, nick: string, privateMessage: boolean, ts: *
-            } = {}) {
+    notifyReceivedChatMessage({
+        body,
+        id,
+        nick,
+        privateMessage,
+        ts
+    }: {
+        body: *,
+        id: string,
+        nick: string,
+        privateMessage: boolean,
+        ts: *
+    } = {}) {
         if (APP.conference.isLocalId(id)) {
             return;
         }
@@ -769,7 +820,8 @@ class API {
      */
     notifyDisplayNameChanged(
             id: string,
-            { displayName, formattedDisplayName }: Object) {
+            { displayName, formattedDisplayName }: Object
+    ) {
         this._sendEvent({
             name: 'display-name-change',
             displayname: displayName,
@@ -786,9 +838,7 @@ class API {
      * @param {string} email - The new email of the participant.
      * @returns {void}
      */
-    notifyEmailChanged(
-            id: string,
-            { email }: Object) {
+    notifyEmailChanged(id: string, { email }: Object) {
         this._sendEvent({
             name: 'email-change',
             email,

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1119,6 +1119,23 @@ class API {
     }
 
     /**
+     * Notify external application (if API is enabled) that user updated its background information.
+     *
+     * @param {string} updaterId - Updater ID.
+     * @param {string} localId - Local participant ID.
+     * @param {Object} backgroundData - Background image/color object.
+     * @returns {void}
+     */
+    notifyBackgroundChanged(updaterId: string, localId: string, backgroundData: Object) {
+        this._sendEvent({
+            name: 'room-background-updated',
+            backgroundData,
+            localId,
+            updaterId
+        });
+    }
+
+    /**
      * Disposes the allocated resources.
      *
      * @returns {void}

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -11,15 +11,9 @@ import {
 } from '../../react/features/base/conference';
 import { overwriteConfig, getWhitelistedJSON } from '../../react/features/base/config';
 import { parseJWTFromURLParams } from '../../react/features/base/jwt';
-import JitsiMeetJS, {
-    JitsiRecordingConstants
-} from '../../react/features/base/lib-jitsi-meet';
+import JitsiMeetJS, { JitsiRecordingConstants } from '../../react/features/base/lib-jitsi-meet';
 import { MEDIA_TYPE } from '../../react/features/base/media';
-import {
-    pinParticipant,
-    getParticipantById,
-    kickParticipant
-} from '../../react/features/base/participants';
+import { pinParticipant, getParticipantById, kickParticipant } from '../../react/features/base/participants';
 import { setPrivateMessageRecipient } from '../../react/features/chat/actions';
 import { openChat } from '../../react/features/chat/actions.web';
 import { processExternalDeviceRequest } from '../../react/features/device-selection/functions';
@@ -86,9 +80,7 @@ function initCommands() {
             const muteMediaType = mediaType ? mediaType : MEDIA_TYPE.AUDIO;
 
             sendAnalytics(createApiEvent('muted-everyone'));
-            const participants = APP.store.getState()[
-                'features/base/participants'
-            ];
+            const participants = APP.store.getState()['features/base/participants'];
             const localIds = participants
                 .filter(participant => participant.local)
                 .filter(participant => participant.role === 'moderator')
@@ -100,20 +92,17 @@ function initCommands() {
             APP.store.dispatch(toggleLobbyMode(isLobbyEnabled));
         },
         'password': password => {
-            const { conference, passwordRequired } = APP.store.getState()[
-                'features/base/conference'
-            ];
+            const { conference, passwordRequired }
+                = APP.store.getState()['features/base/conference'];
 
             if (passwordRequired) {
                 sendAnalytics(createApiEvent('submit.password'));
 
-                APP.store.dispatch(
-                    setPassword(
-                        passwordRequired,
-                        passwordRequired.join,
-                        password
-                    )
-                );
+                APP.store.dispatch(setPassword(
+                    passwordRequired,
+                    passwordRequired.join,
+                    password
+                ));
             } else {
                 sendAnalytics(createApiEvent('password.changed'));
 
@@ -139,22 +128,7 @@ function initCommands() {
             APP.store.dispatch(sendTones(tones, duration, pause));
         },
         'set-background-image': (backgroundImageUrl, backgroundColor) => {
-            const state = APP.store.getState();
-
-            console.log('general state : ');
-            console.log(state);
-            const participants = APP.store.getState()[
-                'features/base/participants'
-            ];
-
-            console.log('Participants state : ');
-            console.log(participants);
-            const conference = APP.store.getState()[
-                'features/base/conference'
-            ];
-
-            console.log('Conference state : ');
-            console.log(conference);
+            logger.debug('Set background image command received');
             APP.conference.setBackgroundImage(backgroundImageUrl, backgroundColor);
         },
         'set-large-video-participant': participantId => {
@@ -277,20 +251,13 @@ function initCommands() {
             }
 
             if (dropboxToken && !isDropboxEnabled(state)) {
-                logger.error(
-                    'Failed starting recording: dropbox is not enabled on this deployment'
-                );
+                logger.error('Failed starting recording: dropbox is not enabled on this deployment');
 
                 return;
             }
 
-            if (
-                mode === JitsiRecordingConstants.mode.STREAM
-                && !(youtubeStreamKey || rtmpStreamKey)
-            ) {
-                logger.error(
-                    'Failed starting recording: missing youtube or RTMP stream key'
-                );
+            if (mode === JitsiRecordingConstants.mode.STREAM && !(youtubeStreamKey || rtmpStreamKey)) {
+                logger.error('Failed starting recording: missing youtube or RTMP stream key');
 
                 return;
             }
@@ -305,7 +272,7 @@ function initCommands() {
                             'file_recording_metadata': {
                                 'upload_credentials': {
                                     'service_name': RECORDING_TYPES.DROPBOX,
-                                    token: dropboxToken
+                                    'token': dropboxToken
                                 }
                             }
                         })
@@ -315,7 +282,7 @@ function initCommands() {
                         mode: JitsiRecordingConstants.mode.FILE,
                         appData: JSON.stringify({
                             'file_recording_metadata': {
-                                share: shouldShare
+                                'share': shouldShare
                             }
                         })
                     };
@@ -351,12 +318,7 @@ function initCommands() {
                 return;
             }
 
-            if (
-                ![
-                    JitsiRecordingConstants.mode.FILE,
-                    JitsiRecordingConstants.mode.STREAM
-                ].includes(mode)
-            ) {
+            if (![ JitsiRecordingConstants.mode.FILE, JitsiRecordingConstants.mode.STREAM ].includes(mode)) {
                 logger.error('Invalid recording mode provided!');
 
                 return;
@@ -382,9 +344,7 @@ function initCommands() {
                 }
                 APP.store.dispatch(openChat(participant));
             } else {
-                logger.error(
-                    'No participant found for the given participantId'
-                );
+                logger.error('No participant found for the given participantId');
             }
         },
         'cancel-private-chat': () => {
@@ -419,8 +379,7 @@ function initCommands() {
 
         switch (name) {
         case 'capture-largevideo-screenshot':
-            APP.store
-                    .dispatch(captureLargeVideoScreenshot())
+            APP.store.dispatch(captureLargeVideoScreenshot())
                     .then(dataURL => {
                         let error;
 
@@ -447,8 +406,8 @@ function initCommands() {
 
             // The store should be already available because API.init is called
             // on appWillMount action.
-            APP.store
-                    .dispatch(invite(invitees, true))
+            APP.store.dispatch(
+                    invite(invitees, true))
                     .then(failedInvitees => {
                         let error;
                         let result;
@@ -483,9 +442,7 @@ function initCommands() {
             break;
         case 'get-content-sharing-participants': {
             const tracks = getState()['features/base/tracks'];
-            const sharingParticipantIds = tracks
-                    .filter(tr => tr.videoType === 'desktop')
-                    .map(t => t.participantId);
+            const sharingParticipantIds = tracks.filter(tr => tr.videoType === 'desktop').map(t => t.participantId);
 
             callback({
                 sharingParticipantIds
@@ -498,10 +455,7 @@ function initCommands() {
             let livestreamUrl;
 
             if (conference) {
-                const activeSession = getActiveSession(
-                        state,
-                        JitsiRecordingConstants.mode.STREAM
-                );
+                const activeSession = getActiveSession(state, JitsiRecordingConstants.mode.STREAM);
 
                 livestreamUrl = activeSession?.liveStreamViewURL;
             } else {
@@ -678,19 +632,10 @@ class API {
      * @param {Object} options - Object with the message properties.
      * @returns {void}
      */
-    notifyReceivedChatMessage({
-        body,
-        id,
-        nick,
-        privateMessage,
-        ts
-    }: {
-        body: *,
-        id: string,
-        nick: string,
-        privateMessage: boolean,
-        ts: *
-    } = {}) {
+    notifyReceivedChatMessage(
+            { body, id, nick, privateMessage, ts }: {
+            body: *, id: string, nick: string, privateMessage: boolean, ts: *
+        } = {}) {
         if (APP.conference.isLocalId(id)) {
             return;
         }
@@ -820,8 +765,7 @@ class API {
      */
     notifyDisplayNameChanged(
             id: string,
-            { displayName, formattedDisplayName }: Object
-    ) {
+            { displayName, formattedDisplayName }: Object) {
         this._sendEvent({
             name: 'display-name-change',
             displayname: displayName,

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -87,6 +87,7 @@ const events = {
     'password-required': 'passwordRequired',
     'proxy-connection-event': 'proxyConnectionEvent',
     'raise-hand-updated': 'raiseHandUpdated',
+    'room-background-updated': 'roomBackgroundUpdated',
     'video-ready-to-close': 'readyToClose',
     'video-conference-joined': 'videoConferenceJoined',
     'video-conference-left': 'videoConferenceLeft',

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -77,7 +77,7 @@ const events = {
     'feedback-prompt-displayed': 'feedbackPromptDisplayed',
     'filmstrip-display-changed': 'filmstripDisplayChanged',
     'incoming-message': 'incomingMessage',
-    log: 'log',
+    'log': 'log',
     'mic-error': 'micError',
     'outgoing-message': 'outgoingMessage',
     'participant-joined': 'participantJoined',
@@ -217,6 +217,7 @@ function parseSizeParam(value) {
     return parsedValue;
 }
 
+
 /**
  * The IFrame API interface class.
  */
@@ -267,9 +268,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             userInfo,
             e2eeKey
         } = parseArguments(args);
-        const localStorageContent = jitsiLocalStorage.getItem(
-            'jitsiLocalStorage'
-        );
+        const localStorageContent = jitsiLocalStorage.getItem('jitsiLocalStorage');
 
         this._parentNode = parentNode;
         this._url = generateURL(domain, {
@@ -323,8 +322,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const frameName = `jitsiConferenceFrame${id}`;
 
         this._frame = document.createElement('iframe');
-        this._frame.allow
-            = 'camera; microphone; display-capture; autoplay; clipboard-write';
+        this._frame.allow = 'camera; microphone; display-capture; autoplay; clipboard-write';
         this._frame.src = this._url;
         this._frame.name = frameName;
         this._frame.id = frameName;
@@ -387,6 +385,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         return this._onStageParticipant;
     }
 
+
     /**
      * Getter for the large video element in Jitsi Meet.
      *
@@ -422,13 +421,8 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             return;
         }
 
-        if (
-            typeof participantId === 'undefined'
-            || participantId === this._myUserID
-        ) {
-            return iframe.contentWindow.document.getElementById(
-                'localVideo_container'
-            );
+        if (typeof participantId === 'undefined' || participantId === this._myUserID) {
+            return iframe.contentWindow.document.getElementById('localVideo_container');
         }
 
         return iframe.contentWindow.document.querySelector(`#participant_${participantId} video`);
@@ -481,10 +475,10 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
                     avatarURL: data.avatarURL
                 };
             }
+
             // eslint-disable-next-line no-fallthrough
             case 'participant-joined': {
-                this._participants[userID]
-                        = this._participants[userID] || {};
+                this._participants[userID] = this._participants[userID] || {};
                 this._participants[userID].displayName = data.displayName;
                 this._participants[userID].formattedDisplayName
                         = data.formattedDisplayName;
@@ -536,10 +530,7 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
                 this._videoQuality = data.videoQuality;
                 break;
             case 'local-storage-changed':
-                jitsiLocalStorage.setItem(
-                        'jitsiLocalStorage',
-                        data.localStorageContent
-                );
+                jitsiLocalStorage.setItem('jitsiLocalStorage', data.localStorageContent);
 
                 // Since this is internal event we don't need to emit it to the consumer of the API.
                 return true;

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -43,6 +43,7 @@ const commands = {
     resizeLargeVideo: 'resize-large-video',
     sendEndpointTextMessage: 'send-endpoint-text-message',
     sendTones: 'send-tones',
+    setBackgroundImage: 'set-background-image',
     setLargeVideoParticipant: 'set-large-video-participant',
     setVideoQuality: 'set-video-quality',
     startRecording: 'start-recording',
@@ -76,7 +77,7 @@ const events = {
     'feedback-prompt-displayed': 'feedbackPromptDisplayed',
     'filmstrip-display-changed': 'filmstripDisplayChanged',
     'incoming-message': 'incomingMessage',
-    'log': 'log',
+    log: 'log',
     'mic-error': 'micError',
     'outgoing-message': 'outgoingMessage',
     'participant-joined': 'participantJoined',
@@ -216,7 +217,6 @@ function parseSizeParam(value) {
     return parsedValue;
 }
 
-
 /**
  * The IFrame API interface class.
  */
@@ -267,7 +267,9 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             userInfo,
             e2eeKey
         } = parseArguments(args);
-        const localStorageContent = jitsiLocalStorage.getItem('jitsiLocalStorage');
+        const localStorageContent = jitsiLocalStorage.getItem(
+            'jitsiLocalStorage'
+        );
 
         this._parentNode = parentNode;
         this._url = generateURL(domain, {
@@ -321,7 +323,8 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const frameName = `jitsiConferenceFrame${id}`;
 
         this._frame = document.createElement('iframe');
-        this._frame.allow = 'camera; microphone; display-capture; autoplay; clipboard-write';
+        this._frame.allow
+            = 'camera; microphone; display-capture; autoplay; clipboard-write';
         this._frame.src = this._url;
         this._frame.name = frameName;
         this._frame.id = frameName;
@@ -384,7 +387,6 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         return this._onStageParticipant;
     }
 
-
     /**
      * Getter for the large video element in Jitsi Meet.
      *
@@ -420,8 +422,13 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             return;
         }
 
-        if (typeof participantId === 'undefined' || participantId === this._myUserID) {
-            return iframe.contentWindow.document.getElementById('localVideo_container');
+        if (
+            typeof participantId === 'undefined'
+            || participantId === this._myUserID
+        ) {
+            return iframe.contentWindow.document.getElementById(
+                'localVideo_container'
+            );
         }
 
         return iframe.contentWindow.document.querySelector(`#participant_${participantId} video`);
@@ -474,10 +481,10 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
                     avatarURL: data.avatarURL
                 };
             }
-
             // eslint-disable-next-line no-fallthrough
             case 'participant-joined': {
-                this._participants[userID] = this._participants[userID] || {};
+                this._participants[userID]
+                        = this._participants[userID] || {};
                 this._participants[userID].displayName = data.displayName;
                 this._participants[userID].formattedDisplayName
                         = data.formattedDisplayName;
@@ -529,7 +536,10 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
                 this._videoQuality = data.videoQuality;
                 break;
             case 'local-storage-changed':
-                jitsiLocalStorage.setItem('jitsiLocalStorage', data.localStorageContent);
+                jitsiLocalStorage.setItem(
+                        'jitsiLocalStorage',
+                        data.localStorageContent
+                );
 
                 // Since this is internal event we don't need to emit it to the consumer of the API.
                 return true;
@@ -1104,5 +1114,20 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      */
     stopRecording(mode) {
         this.executeCommand('startRecording', mode);
+    }
+
+    /**
+     * Sets a background image for the room.
+     *
+     * @param {string} backgroundImageUrl - URL of the background image.
+     * @param {string} backgroundColor - Custom color code for the background.
+     * @returns {void}
+     */
+    setBackgroundImage(backgroundImageUrl, backgroundColor) {
+        this.executeCommand(
+            'setBackgroundImage',
+            backgroundImageUrl,
+            backgroundColor
+        );
     }
 }

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -418,9 +418,9 @@ export class VideoContainer extends LargeContainer {
         const [ videoWidth, videoHeight ] = this._getVideoSize(containerWidth, containerHeight, backgroundRoomDefined);
 
         // If a background is defined for the room, we resize the video so that the background is visible
-        const width = backgroundRoomDefined ? videoWidth * BACKGROUND_RESIZING_RATIO : videoWidth;
-        const height = backgroundRoomDefined ? videoHeight * BACKGROUND_RESIZING_RATIO : videoHeight;
-
+        const shouldResizeVideo = backgroundRoomDefined && !this.isScreenSharing();
+        const width = shouldResizeVideo ? videoWidth * BACKGROUND_RESIZING_RATIO : videoWidth;
+        const height = shouldResizeVideo ? videoHeight * BACKGROUND_RESIZING_RATIO : videoHeight;
 
         if (width === 0 || height === 0) {
             // We don't need to set 0 for width or height since the visibility is controled by the visibility css prop

--- a/modules/UI/videolayout/VideoContainer.js
+++ b/modules/UI/videolayout/VideoContainer.js
@@ -7,6 +7,7 @@ import ReactDOM from 'react-dom';
 import { browser } from '../../../react/features/base/lib-jitsi-meet';
 import { isTestModeEnabled } from '../../../react/features/base/testing';
 import { ORIENTATION, LargeVideoBackground, updateLastLargeVideoMediaEvent } from '../../../react/features/large-video';
+import { isRoomBackgroundDefined } from '../../../react/features/room-background';
 import { LAYOUTS, getCurrentLayout } from '../../../react/features/video-layout';
 /* eslint-enable no-unused-vars */
 import UIEvents from '../../../service/UI/UIEvents';
@@ -19,6 +20,7 @@ import LargeContainer from './LargeContainer';
 export const VIDEO_CONTAINER_TYPE = 'camera';
 
 const FADE_DURATION_MS = 300;
+const BACKGROUND_RESIZING_RATIO = 0.7;
 
 /**
  * List of container events that we are going to process, will be added as listener to the
@@ -108,18 +110,18 @@ function computeCameraVideoSize( // eslint-disable-line max-params
     case 'both': {
         const videoSpaceRatio = videoSpaceWidth / videoSpaceHeight;
         const maxZoomCoefficient = interfaceConfig.MAXIMUM_ZOOMING_COEFFICIENT
-            || Infinity;
+                || Infinity;
 
         if (videoSpaceRatio === aspectRatio) {
             return [ videoSpaceWidth, videoSpaceHeight ];
         }
 
         let [ width, height ] = computeCameraVideoSize(
-            videoWidth,
-            videoHeight,
-            videoSpaceWidth,
-            videoSpaceHeight,
-            videoSpaceRatio < aspectRatio ? 'height' : 'width');
+                videoWidth,
+                videoHeight,
+                videoSpaceWidth,
+                videoSpaceHeight,
+                videoSpaceRatio < aspectRatio ? 'height' : 'width');
         const maxWidth = videoSpaceWidth * maxZoomCoefficient;
         const maxHeight = videoSpaceHeight * maxZoomCoefficient;
 
@@ -161,8 +163,10 @@ function getCameraVideoPosition( // eslint-disable-line max-params
     const horizontalIndent = (videoSpaceWidth - videoWidth) / 2;
     const verticalIndent = (videoSpaceHeight - videoHeight) / 2;
 
-    return { horizontalIndent,
-        verticalIndent };
+    return {
+        horizontalIndent,
+        verticalIndent
+    };
 }
 
 /**
@@ -349,9 +353,9 @@ export class VideoContainer extends LargeContainer {
         }
 
         return getCameraVideoPosition(width,
-                height,
-                containerWidthToUse,
-                containerHeight);
+            height,
+            containerWidthToUse,
+            containerHeight);
 
     }
 
@@ -398,7 +402,10 @@ export class VideoContainer extends LargeContainer {
         if (this.$video.length === 0) {
             return;
         }
-        const currentLayout = getCurrentLayout(APP.store.getState());
+
+        const state = APP.store.getState();
+        const currentLayout = getCurrentLayout(state);
+        const backgroundRoomDefined = isRoomBackgroundDefined(state);
 
         if (currentLayout === LAYOUTS.TILE_VIEW) {
             // We don't need to resize the large video since it won't be displayed and we'll resize when returning back
@@ -408,7 +415,12 @@ export class VideoContainer extends LargeContainer {
 
         this.positionRemoteStatusMessages();
 
-        const [ width, height ] = this._getVideoSize(containerWidth, containerHeight);
+        const [ videoWidth, videoHeight ] = this._getVideoSize(containerWidth, containerHeight, backgroundRoomDefined);
+
+        // If a background is defined for the room, we resize the video so that the background is visible
+        const width = backgroundRoomDefined ? videoWidth * BACKGROUND_RESIZING_RATIO : videoWidth;
+        const height = backgroundRoomDefined ? videoHeight * BACKGROUND_RESIZING_RATIO : videoHeight;
+
 
         if (width === 0 || height === 0) {
             // We don't need to set 0 for width or height since the visibility is controled by the visibility css prop
@@ -419,7 +431,9 @@ export class VideoContainer extends LargeContainer {
             return;
         }
 
-        if ((containerWidth > width) || (containerHeight > height)) {
+        if (backgroundRoomDefined) {
+            this._hideBackground = true;
+        } else if ((containerWidth > width) || (containerHeight > height)) {
             this._backgroundOrientation = containerWidth > width ? ORIENTATION.LANDSCAPE : ORIENTATION.PORTRAIT;
             this._hideBackground = false;
         } else {
@@ -609,22 +623,22 @@ export class VideoContainer extends LargeContainer {
         // performance issues from the presence of the background or if
         // explicitly disabled.
         if (interfaceConfig.DISABLE_VIDEO_BACKGROUND
-                || browser.isFirefox()
-                || browser.isWebKitBased()) {
+            || browser.isFirefox()
+            || browser.isWebKitBased()) {
             return;
         }
 
         ReactDOM.render(
             <LargeVideoBackground
-                hidden = { this._hideBackground || this._isHidden }
-                mirror = {
+                hidden={this._hideBackground || this._isHidden}
+                mirror={
                     this.stream
                     && this.stream.isLocal()
                     && this.localFlipX
                 }
-                orientationFit = { this._backgroundOrientation }
-                videoElement = { this.$video && this.$video[0] }
-                videoTrack = { this.stream } />,
+                orientationFit={this._backgroundOrientation}
+                videoElement={this.$video && this.$video[0]}
+                videoTrack={this.stream} />,
             document.getElementById('largeVideoBackgroundContainer')
         );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5866,6 +5866,15 @@
         "lodash": "^4.17.10"
       }
     },
+    "eslint-plugin-flowtype": {
+      "version": "2.50.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.50.3.tgz",
+      "integrity": "sha512-X+AoKVOr7Re0ko/yEXyM5SSZ0tazc6ffdIOocp2fFUlWoDt7DV0Bz99mngOkAFLOAWjqRA5jPwqUCbrx13XoxQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.20.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz",
@@ -12810,6 +12819,24 @@
             "ansi-regex": "^3.0.0"
           }
         }
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimend": {

--- a/react/features/app/middlewares.any.js
+++ b/react/features/app/middlewares.any.js
@@ -37,6 +37,7 @@ import '../overlay/middleware';
 import '../recent-list/middleware';
 import '../recording/middleware';
 import '../rejoin/middleware';
+import '../room-background/middleware';
 import '../room-lock/middleware';
 import '../rtcstats/middleware';
 import '../subtitles/middleware';

--- a/react/features/app/reducers.any.js
+++ b/react/features/app/reducers.any.js
@@ -42,6 +42,7 @@ import '../notifications/reducer';
 import '../overlay/reducer';
 import '../recent-list/reducer';
 import '../recording/reducer';
+import '../room-background/reducer';
 import '../settings/reducer';
 import '../subtitles/reducer';
 import '../toolbox/reducer';

--- a/react/features/base/participants/actions.js
+++ b/react/features/base/participants/actions.js
@@ -2,9 +2,6 @@ import { NOTIFICATION_TIMEOUT, showNotification } from '../../notifications';
 import { set } from '../redux';
 
 import {
-    updateSettings
-} from './../settings';
-import {
     DOMINANT_SPEAKER_CHANGED,
     HIDDEN_PARTICIPANT_JOINED,
     HIDDEN_PARTICIPANT_LEFT,
@@ -549,21 +546,5 @@ export function setLoadableAvatarUrl(participantId, url) {
             id: participantId,
             loadableAvatarUrl: url
         }
-    };
-}
-export function setLocalParticipantBackground(backgroundData) {
-    return (dispatch, getState) => {
-
-        const localParticipant = getLocalParticipant(getState());
-
-        // Update local participants background information
-        dispatch(participantUpdated({
-            localParticipant,
-            backgroundData
-        }));
-
-        dispatch(updateSettings({
-            backgroundData
-        }));
     };
 }

--- a/react/features/base/participants/actions.js
+++ b/react/features/base/participants/actions.js
@@ -2,6 +2,9 @@ import { NOTIFICATION_TIMEOUT, showNotification } from '../../notifications';
 import { set } from '../redux';
 
 import {
+    updateSettings
+} from './../settings';
+import {
     DOMINANT_SPEAKER_CHANGED,
     HIDDEN_PARTICIPANT_JOINED,
     HIDDEN_PARTICIPANT_LEFT,
@@ -548,4 +551,19 @@ export function setLoadableAvatarUrl(participantId, url) {
         }
     };
 }
+export function setLocalParticipantBackground(backgroundData) {
+    return (dispatch, getState) => {
 
+        const localParticipant = getLocalParticipant(getState());
+
+        // Update local participants background information
+        dispatch(participantUpdated({
+            localParticipant,
+            backgroundData
+        }));
+
+        dispatch(updateSettings({
+            backgroundData
+        }));
+    };
+}

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -12,7 +12,6 @@ import {
 } from '../conference';
 import { JitsiConferenceEvents } from '../lib-jitsi-meet';
 import { MiddlewareRegistry, StateListenerRegistry } from '../redux';
-import { updateSettings } from '../settings';
 import { playSound, registerSound, unregisterSound } from '../sounds';
 
 import {
@@ -314,12 +313,8 @@ function _backgroundDataUpdated({ dispatch }, conference, participants, newValue
 
     // Update the local participant information
     dispatch(participantUpdated({
-        conference,
         id: localParticipant.id,
-        backgroundData: newValue
-    }));
-
-    dispatch(updateSettings({
+        local: localParticipant.local,
         backgroundData: newValue
     }));
 

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -379,8 +379,7 @@ function _maybePlaySounds({ getState, dispatch }, action) {
  */
 function _participantJoinedOrUpdated(store, next, action) {
     const { dispatch, getState } = store;
-    const { participant: { avatarURL, e2eeEnabled, email, id, local, name, raisedHand, backgroundColor,
-        backgroundImageUrl, backgroundLastUpdate } } = action;
+    const { participant: { avatarURL, e2eeEnabled, email, id, local, name, raisedHand, backgroundData } } = action;
 
     // Send an external update of the local participant's raised hand state
     // if a new raised hand state is defined in the action.
@@ -397,19 +396,11 @@ function _participantJoinedOrUpdated(store, next, action) {
 
     // Send an external update of the local participant's background color/image state
     // if a new background color/image state is defined in the action.
-    if (typeof backgroundLastUpdate !== 'undefined') {
+    if (typeof backgroundData !== 'undefined') {
         if (local) {
             const { conference } = getState()['features/base/conference'];
 
-            conference.setLocalParticipantProperty('backgroundLastUpdate', backgroundLastUpdate);
-
-            if (conference && backgroundColor !== getLocalParticipant(getState()).backgroundColor) {
-                conference.setLocalParticipantProperty('backgroundColor', backgroundColor);
-            }
-
-            if (conference && backgroundImageUrl !== getLocalParticipant(getState()).backgroundImageUrl) {
-                conference.setLocalParticipantProperty('backgroundImageUrl', backgroundImageUrl);
-            }
+            conference.setLocalParticipantProperty('backgroundData', backgroundData);
         }
     }
 

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -58,35 +58,35 @@ declare var APP: Object;
  */
 MiddlewareRegistry.register(store => next => action => {
     switch (action.type) {
-        case APP_WILL_MOUNT:
-            _registerSounds(store);
+    case APP_WILL_MOUNT:
+        _registerSounds(store);
 
-            return _localParticipantJoined(store, next, action);
+        return _localParticipantJoined(store, next, action);
 
-        case APP_WILL_UNMOUNT:
-            _unregisterSounds(store);
+    case APP_WILL_UNMOUNT:
+        _unregisterSounds(store);
 
-            return _localParticipantLeft(store, next, action);
+        return _localParticipantLeft(store, next, action);
 
-        case CONFERENCE_WILL_JOIN:
-            store.dispatch(localParticipantIdChanged(action.conference.myUserId()));
+    case CONFERENCE_WILL_JOIN:
+        store.dispatch(localParticipantIdChanged(action.conference.myUserId()));
+        break;
+
+    case DOMINANT_SPEAKER_CHANGED: {
+        // Ensure the raised hand state is cleared for the dominant speaker
+        // and only if it was set when this is the local participant
+
+        const { conference, id } = action.participant;
+        const participant = getLocalParticipant(store.getState());
+        const isLocal = participant && participant.id === id;
+
+        if (isLocal && participant.raisedHand === undefined) {
+            // if local was undefined, let's leave it like that
+            // avoids sending unnecessary presence updates
             break;
+        }
 
-        case DOMINANT_SPEAKER_CHANGED: {
-            // Ensure the raised hand state is cleared for the dominant speaker
-            // and only if it was set when this is the local participant
-
-            const { conference, id } = action.participant;
-            const participant = getLocalParticipant(store.getState());
-            const isLocal = participant && participant.id === id;
-
-            if (isLocal && participant.raisedHand === undefined) {
-                // if local was undefined, let's leave it like that
-                // avoids sending unnecessary presence updates
-                break;
-            }
-
-            participant
+        participant
                 && store.dispatch(participantUpdated({
                     conference,
                     id,
@@ -94,56 +94,56 @@ MiddlewareRegistry.register(store => next => action => {
                     raisedHand: false
                 }));
 
-            break;
-        }
+        break;
+    }
 
-        case GRANT_MODERATOR: {
-            const { conference } = store.getState()['features/base/conference'];
+    case GRANT_MODERATOR: {
+        const { conference } = store.getState()['features/base/conference'];
 
-            conference.grantOwner(action.id);
-            break;
-        }
+        conference.grantOwner(action.id);
+        break;
+    }
 
-        case KICK_PARTICIPANT: {
-            const { conference } = store.getState()['features/base/conference'];
+    case KICK_PARTICIPANT: {
+        const { conference } = store.getState()['features/base/conference'];
 
-            conference.kickParticipant(action.id);
-            break;
-        }
+        conference.kickParticipant(action.id);
+        break;
+    }
 
-        case MUTE_REMOTE_PARTICIPANT: {
-            const { conference } = store.getState()['features/base/conference'];
+    case MUTE_REMOTE_PARTICIPANT: {
+        const { conference } = store.getState()['features/base/conference'];
 
-            conference.muteParticipant(action.id, action.mediaType);
-            break;
-        }
+        conference.muteParticipant(action.id, action.mediaType);
+        break;
+    }
 
-        // TODO Remove this middleware when the local display name update flow is
-        // fully brought into redux.
-        case PARTICIPANT_DISPLAY_NAME_CHANGED: {
-            if (typeof APP !== 'undefined') {
-                const participant = getLocalParticipant(store.getState());
+    // TODO Remove this middleware when the local display name update flow is
+    // fully brought into redux.
+    case PARTICIPANT_DISPLAY_NAME_CHANGED: {
+        if (typeof APP !== 'undefined') {
+            const participant = getLocalParticipant(store.getState());
 
-                if (participant && participant.id === action.id) {
-                    APP.UI.emitEvent(UIEvents.NICKNAME_CHANGED, action.name);
-                }
+            if (participant && participant.id === action.id) {
+                APP.UI.emitEvent(UIEvents.NICKNAME_CHANGED, action.name);
             }
-
-            break;
         }
 
-        case PARTICIPANT_JOINED: {
-            _maybePlaySounds(store, action);
+        break;
+    }
 
-            return _participantJoinedOrUpdated(store, next, action);
-        }
+    case PARTICIPANT_JOINED: {
+        _maybePlaySounds(store, action);
 
-        case PARTICIPANT_LEFT:
-            _maybePlaySounds(store, action);
-            break;
+        return _participantJoinedOrUpdated(store, next, action);
+    }
 
-        case PARTICIPANT_UPDATED:
-            return _participantJoinedOrUpdated(store, next, action);
+    case PARTICIPANT_LEFT:
+        _maybePlaySounds(store, action);
+        break;
+
+    case PARTICIPANT_UPDATED:
+        return _participantJoinedOrUpdated(store, next, action);
 
     }
 

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -434,7 +434,9 @@ function _participantJoinedOrUpdated(store, next, action) {
         if (local) {
             const { conference } = getState()['features/base/conference'];
 
-            conference.setLocalParticipantProperty('backgroundData', backgroundData);
+            if (conference) {
+                conference.setLocalParticipantProperty('backgroundData', backgroundData);
+            }
         }
     }
 

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -260,6 +260,7 @@ StateListenerRegistry.register(
             // We left the conference, the local participant must be updated.
             _e2eeUpdated(store, conference, localParticipantId, false);
             _raiseHandUpdated(store, conference, localParticipantId, false);
+
         }
     }
 );
@@ -378,7 +379,8 @@ function _maybePlaySounds({ getState, dispatch }, action) {
  */
 function _participantJoinedOrUpdated(store, next, action) {
     const { dispatch, getState } = store;
-    const { participant: { avatarURL, e2eeEnabled, email, id, local, name, raisedHand } } = action;
+    const { participant: { avatarURL, e2eeEnabled, email, id, local, name, raisedHand, backgroundColor,
+        backgroundImageUrl, backgroundLastUpdate } } = action;
 
     // Send an external update of the local participant's raised hand state
     // if a new raised hand state is defined in the action.
@@ -389,6 +391,24 @@ function _participantJoinedOrUpdated(store, next, action) {
             // Send raisedHand signalling only if there is a change
             if (conference && raisedHand !== getLocalParticipant(getState()).raisedHand) {
                 conference.setLocalParticipantProperty('raisedHand', raisedHand);
+            }
+        }
+    }
+
+    // Send an external update of the local participant's background color/image state
+    // if a new background color/image state is defined in the action.
+    if (typeof backgroundLastUpdate !== 'undefined') {
+        if (local) {
+            const { conference } = getState()['features/base/conference'];
+
+            conference.setLocalParticipantProperty('backgroundLastUpdate', backgroundLastUpdate);
+
+            if (conference && backgroundColor !== getLocalParticipant(getState()).backgroundColor) {
+                conference.setLocalParticipantProperty('backgroundColor', backgroundColor);
+            }
+
+            if (conference && backgroundImageUrl !== getLocalParticipant(getState()).backgroundImageUrl) {
+                conference.setLocalParticipantProperty('backgroundImageUrl', backgroundImageUrl);
             }
         }
     }

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -69,6 +69,10 @@ ReducerRegistry.register('features/base/participants', (state = [], action) => {
     case PARTICIPANT_ID_CHANGED:
     case PARTICIPANT_UPDATED:
     case PIN_PARTICIPANT:
+        console.log('Action received');
+        console.log(action);
+        console.log(state);
+
         return state.map(p => _participant(p, action));
 
     case PARTICIPANT_JOINED:

--- a/react/features/base/participants/reducer.js
+++ b/react/features/base/participants/reducer.js
@@ -69,10 +69,6 @@ ReducerRegistry.register('features/base/participants', (state = [], action) => {
     case PARTICIPANT_ID_CHANGED:
     case PARTICIPANT_UPDATED:
     case PIN_PARTICIPANT:
-        console.log('Action received');
-        console.log(action);
-        console.log(state);
-
         return state.map(p => _participant(p, action));
 
     case PARTICIPANT_JOINED:

--- a/react/features/dynamic-branding/actions.js
+++ b/react/features/dynamic-branding/actions.js
@@ -13,7 +13,6 @@ import { getDynamicBrandingUrl } from './functions';
 
 const logger = getLogger(__filename);
 
-
 /**
  * Fetches custom branding data.
  * If there is no data or the request fails, sets the `customizationReady` flag

--- a/react/features/large-video/actions.web.js
+++ b/react/features/large-video/actions.web.js
@@ -89,6 +89,27 @@ export function resizeLargeVideo(width: number, height: number) {
 }
 
 /**
+ * Resizes the large video elements (adjusted based on the presence of backgrounds).
+ *
+ * @param {boolean} animate - If resize process should be animated.
+ * @returns {Function}
+ */
+export function refreshResizingLargeVideo(animate: boolean) {
+    return (dispatch: Dispatch<any>, getState: Function) => {
+        const state = getState();
+        const largeVideo = state['features/large-video'];
+
+        if (largeVideo) {
+            const largeVideoContainer = VideoLayout.getLargeVideo();
+
+            if (largeVideoContainer) {
+                largeVideoContainer.resize(animate);
+            }
+        }
+    };
+}
+
+/**
  * Updates the last media event received for the large video.
  *
  * @param {string} name - The current media event name for the video.

--- a/react/features/large-video/actions.web.js
+++ b/react/features/large-video/actions.web.js
@@ -80,8 +80,10 @@ export function resizeLargeVideo(width: number, height: number) {
         if (largeVideo) {
             const largeVideoContainer = VideoLayout.getLargeVideo();
 
-            largeVideoContainer.updateContainerSize(width, height);
-            largeVideoContainer.resize();
+            if (largeVideoContainer) {
+                largeVideoContainer.updateContainerSize(width, height);
+                largeVideoContainer.resize();
+            }
         }
     };
 }

--- a/react/features/large-video/components/LargeVideo.web.js
+++ b/react/features/large-video/components/LargeVideo.web.js
@@ -132,43 +132,26 @@ class LargeVideo extends Component<Props> {
 }
 
 /**
- * For a local participant, extract the background-related information from the participant state.
+ * Extract background-relevant information if existing from serialized background properties.
  *
- * @param {Object} participant - The Redux state for participants feature.
+ * @param {Object} serializedBackgroundProperties - Serialized background properties.
  * @private
  * @returns {Object}
  */
-function _extractBackgroundInfo(participant) {
-    const { backgroundColor, backgroundImageUrl, backgroundLastUpdate } = participant;
-
-    return {
-        backgroundColor,
-        backgroundImageUrl,
-        backgroundLastUpdate
-    };
-}
-
-/**
- * For a remote participant, extract the background-related information from the conference state.
- *
- * @param {Object} participant - Participant related information in the conference state.
- * @private
- * @returns {Object}
- */
-function _extractBackgroundInfoRemote(participant) {
-    if (!participant?._properties) {
+function _extractBackgroundProperties(serializedBackgroundProperties) {
+    if (!serializedBackgroundProperties) {
         return {
+            backgroundLastUpdate: undefined,
             backgroundColor: undefined,
-            backgroundImageUrl: undefined,
-            backgroundLastUpdate: undefined
+            backgroundImageUrl: undefined
         };
     }
-    const properties = participant?._properties;
+    const unparsedBackgroundData = serializedBackgroundProperties.split('|');
 
     return {
-        backgroundColor: properties.backgroundColor,
-        backgroundImageUrl: properties.backgroundImageUrl,
-        backgroundLastUpdate: properties.backgroundLastUpdate
+        backgroundLastUpdate: unparsedBackgroundData[0],
+        backgroundColor: unparsedBackgroundData[1],
+        backgroundImageUrl: unparsedBackgroundData[2]
     };
 }
 
@@ -185,12 +168,12 @@ function _getLatestBackground(participantsState, conferenceState) {
 
     const localParticipant = participantsState
         .filter(participant => participant.local)
-        .map(p => _extractBackgroundInfo(p));
+        .map(p => _extractBackgroundProperties(p?.backgroundData));
 
     const remoteParticipants = participantsState
         .filter(participant => !participant.local)
         .map(p => (conferenceState?.participants || {})[p.id])
-        .map(p => _extractBackgroundInfoRemote(p));
+        .map(p => _extractBackgroundProperties(p?._properties?.backgroundData));
 
     const participants = localParticipant
         .concat(remoteParticipants)

--- a/react/features/large-video/components/LargeVideo.web.js
+++ b/react/features/large-video/components/LargeVideo.web.js
@@ -6,7 +6,6 @@ import { Watermarks } from '../../base/react';
 import { connect } from '../../base/redux';
 import { InviteMore, Subject } from '../../conference';
 import { fetchCustomBrandingData } from '../../dynamic-branding';
-import { fetchExistingBackgroundData } from '../../room-background';
 import { Captions } from '../../subtitles/';
 
 declare var interfaceConfig: Object;
@@ -27,11 +26,6 @@ type Props = {
      * Fetches the branding data.
      */
     _fetchCustomBrandingData: Function,
-
-    /**
-     * Fetches the existing room background data.
-     */
-    _fetchExistingBackgroundData: Function,
 
     /**
      * Prop that indicates whether the chat is open.
@@ -59,7 +53,6 @@ class LargeVideo extends Component<Props> {
      */
     componentDidMount() {
         this.props._fetchCustomBrandingData();
-        this.props._fetchExistingBackgroundData();
     }
 
     /**
@@ -183,8 +176,7 @@ function _mapStateToProps(state) {
 }
 
 const _mapDispatchToProps = {
-    _fetchCustomBrandingData: fetchCustomBrandingData,
-    _fetchExistingBackgroundData: fetchExistingBackgroundData
+    _fetchCustomBrandingData: fetchCustomBrandingData
 };
 
 export default connect(_mapStateToProps, _mapDispatchToProps)(LargeVideo);

--- a/react/features/large-video/components/LargeVideo.web.js
+++ b/react/features/large-video/components/LargeVideo.web.js
@@ -6,6 +6,7 @@ import { Watermarks } from '../../base/react';
 import { connect } from '../../base/redux';
 import { InviteMore, Subject } from '../../conference';
 import { fetchCustomBrandingData } from '../../dynamic-branding';
+import { fetchExistingBackgroundData } from '../../room-background';
 import { Captions } from '../../subtitles/';
 
 declare var interfaceConfig: Object;
@@ -26,6 +27,11 @@ type Props = {
      * Fetches the branding data.
      */
     _fetchCustomBrandingData: Function,
+
+    /**
+     * Fetches the existing room background data.
+     */
+    _fetchExistingBackgroundData: Function,
 
     /**
      * Prop that indicates whether the chat is open.
@@ -53,6 +59,7 @@ class LargeVideo extends Component<Props> {
      */
     componentDidMount() {
         this.props._fetchCustomBrandingData();
+        this.props._fetchExistingBackgroundData();
     }
 
     /**
@@ -132,80 +139,15 @@ class LargeVideo extends Component<Props> {
 }
 
 /**
- * Extract background-relevant information if existing from serialized background properties.
- *
- * @param {Object} serializedBackgroundProperties - Serialized background properties.
- * @private
- * @returns {Object}
- */
-function _extractBackgroundProperties(serializedBackgroundProperties) {
-    if (!serializedBackgroundProperties) {
-        return {
-            backgroundLastUpdate: undefined,
-            backgroundColor: undefined,
-            backgroundImageUrl: undefined
-        };
-    }
-    const unparsedBackgroundData = serializedBackgroundProperties.split('|');
-
-    return {
-        backgroundLastUpdate: unparsedBackgroundData[0],
-        backgroundColor: unparsedBackgroundData[1],
-        backgroundImageUrl: unparsedBackgroundData[2]
-    };
-}
-
-/**
- * The function synchronizes the information between local and remote participants to get the latest
- * background defined.
- *
- * @param {Object} participantsState - Participants redux state.
- * @param {Object} conferenceState - Conference redux state.
- * @private
- * @returns {Object}
- */
-function _getLatestBackground(participantsState, conferenceState) {
-
-    const localParticipant = participantsState
-        .filter(participant => participant.local)
-        .map(p => _extractBackgroundProperties(p?.backgroundData));
-
-    const remoteParticipants = participantsState
-        .filter(participant => !participant.local)
-        .map(p => (conferenceState?.participants || {})[p.id])
-        .map(p => _extractBackgroundProperties(p?._properties?.backgroundData));
-
-    const participants = localParticipant
-        .concat(remoteParticipants)
-        .filter(participant => participant.backgroundLastUpdate !== undefined);
-
-    console.log('Background participants list : ');
-    console.log(participants);
-    const reference = participants
-        .sort((a, b) => parseInt(b.backgroundLastUpdate, 10) - parseInt(a.backgroundLastUpdate, 10))[0];
-
-    console.log('Background reference chosen : ');
-    console.log(reference);
-
-    return {
-        backgroundColor: reference?.backgroundColor,
-        backgroundImageUrl: reference?.backgroundImageUrl
-    };
-}
-
-/**
- * Returns background properties depending on the states of participants, conference and dynamic branding.
+ * Returns background properties depending on the states of room-background and dynamic branding.
  *
  * @param {Object} state - The Redux state.
  * @private
  * @returns {Object}
  */
 function _resolveBackground(state) {
-    const participantsState = state['features/base/participants'];
-    const conferenceState = state['features/base/conference'].conference;
     const dynamicBrandingState = state['features/dynamic-branding'];
-
-    const { backgroundColor, backgroundImageUrl } = _getLatestBackground(participantsState, conferenceState);
+    const { backgroundColor, backgroundImageUrl } = state['features/room-background'];
 
     if (backgroundColor || backgroundImageUrl) {
         return {
@@ -241,7 +183,8 @@ function _mapStateToProps(state) {
 }
 
 const _mapDispatchToProps = {
-    _fetchCustomBrandingData: fetchCustomBrandingData
+    _fetchCustomBrandingData: fetchCustomBrandingData,
+    _fetchExistingBackgroundData: fetchExistingBackgroundData
 };
 
 export default connect(_mapStateToProps, _mapDispatchToProps)(LargeVideo);

--- a/react/features/room-background/actionTypes.js
+++ b/react/features/room-background/actionTypes.js
@@ -1,0 +1,4 @@
+/**
+ * Action used to set custom room background color/image.
+ */
+export const SET_BACKGROUND_DATA = 'SET_BACKGROUND_DATA';

--- a/react/features/room-background/actions.js
+++ b/react/features/room-background/actions.js
@@ -1,0 +1,65 @@
+// @flow
+
+import {
+    SET_BACKGROUND_DATA
+} from './actionTypes';
+import {
+    getLatestBackground,
+    extractBackgroundProperties
+} from './functions';
+
+/**
+ * When entering the conference, fetch existing background data stored as other
+ * participants properties. The last background set by a participant will be taken.
+ * If none is found, the background properties will be undefined.
+ *
+ * @returns {Function}
+ */
+export function fetchExistingBackgroundData() {
+    return async function(dispatch: Function, getState: Function) {
+        const state = getState();
+        const participantsState = state['features/base/participants'];
+        const conferenceState = state['features/base/conference'].conference;
+        const { backgroundColor, backgroundImageUrl } = getLatestBackground(participantsState, conferenceState);
+
+        return dispatch(setBackgroundData({
+            backgroundColor,
+            backgroundImageUrl
+        }));
+    };
+}
+
+/**
+ * Extract background-relevant information (if existing) from serialized background properties
+ * and update the state of room-background accordingly.
+ *
+ * @param {string} serializedBackgroundData - Serialized background properties ('|' separated).
+ * @private
+ * @returns {Function}
+ */
+export function updateBackgroundData(serializedBackgroundData) {
+    return async function(dispatch: Function) {
+
+        const backgroundDataObject = extractBackgroundProperties(serializedBackgroundData);
+
+        if (backgroundDataObject.backgroundColor || backgroundDataObject.backgroundImageUrl) {
+            return dispatch(setBackgroundData({
+                backgroundColor: backgroundDataObject.backgroundColor,
+                backgroundImageUrl: backgroundDataObject.backgroundImageUrl
+            }));
+        }
+    };
+}
+
+/**
+ * Action used to set the background image/color.
+ *
+ * @param {Object} value - The custom data to be set.
+ * @returns {Object}
+ */
+function setBackgroundData(value) {
+    return {
+        type: SET_BACKGROUND_DATA,
+        value
+    };
+}

--- a/react/features/room-background/actions.js
+++ b/react/features/room-background/actions.js
@@ -20,12 +20,10 @@ export function updateBackgroundData(serializedBackgroundData) {
 
         const backgroundDataObject = extractBackgroundProperties(serializedBackgroundData);
 
-        if (backgroundDataObject.backgroundColor || backgroundDataObject.backgroundImageUrl) {
-            return dispatch(setBackgroundData({
-                backgroundColor: backgroundDataObject.backgroundColor,
-                backgroundImageUrl: backgroundDataObject.backgroundImageUrl
-            }));
-        }
+        return dispatch(setBackgroundData({
+            backgroundColor: backgroundDataObject.backgroundColor,
+            backgroundImageUrl: backgroundDataObject.backgroundImageUrl
+        }));
     };
 }
 

--- a/react/features/room-background/actions.js
+++ b/react/features/room-background/actions.js
@@ -4,30 +4,8 @@ import {
     SET_BACKGROUND_DATA
 } from './actionTypes';
 import {
-    getLatestBackground,
     extractBackgroundProperties
 } from './functions';
-
-/**
- * When entering the conference, fetch existing background data stored as other
- * participants properties. The last background set by a participant will be taken.
- * If none is found, the background properties will be undefined.
- *
- * @returns {Function}
- */
-export function fetchExistingBackgroundData() {
-    return async function(dispatch: Function, getState: Function) {
-        const state = getState();
-        const participantsState = state['features/base/participants'];
-        const conferenceState = state['features/base/conference'].conference;
-        const { backgroundColor, backgroundImageUrl } = getLatestBackground(participantsState, conferenceState);
-
-        return dispatch(setBackgroundData({
-            backgroundColor,
-            backgroundImageUrl
-        }));
-    };
-}
 
 /**
  * Extract background-relevant information (if existing) from serialized background properties
@@ -38,7 +16,7 @@ export function fetchExistingBackgroundData() {
  * @returns {Function}
  */
 export function updateBackgroundData(serializedBackgroundData) {
-    return async function(dispatch: Function) {
+    return dispatch => {
 
         const backgroundDataObject = extractBackgroundProperties(serializedBackgroundData);
 

--- a/react/features/room-background/actions.js
+++ b/react/features/room-background/actions.js
@@ -1,5 +1,7 @@
 // @flow
 
+import type { Dispatch } from 'redux';
+
 import {
     SET_BACKGROUND_DATA
 } from './actionTypes';
@@ -15,7 +17,7 @@ import {
  * @private
  * @returns {Function}
  */
-export function updateBackgroundData(serializedBackgroundData) {
+export function updateBackgroundData(serializedBackgroundData: String) {
     return (dispatch: Dispatch<any>) => {
 
         const backgroundDataObject = extractBackgroundProperties(serializedBackgroundData);

--- a/react/features/room-background/actions.js
+++ b/react/features/room-background/actions.js
@@ -16,7 +16,7 @@ import {
  * @returns {Function}
  */
 export function updateBackgroundData(serializedBackgroundData) {
-    return dispatch => {
+    return (dispatch: Dispatch<any>) => {
 
         const backgroundDataObject = extractBackgroundProperties(serializedBackgroundData);
 

--- a/react/features/room-background/functions.js
+++ b/react/features/room-background/functions.js
@@ -1,0 +1,53 @@
+// @flow
+
+/**
+ * Extract background-relevant information if existing from serialized background properties.
+ *
+ * @param {Object} serializedBackgroundProperties - Serialized background properties ('|' separated).
+ * @private
+ * @returns {Object}
+ */
+export function extractBackgroundProperties(serializedBackgroundProperties) {
+    if (!serializedBackgroundProperties) {
+        return {
+            backgroundLastUpdate: undefined,
+            backgroundColor: undefined,
+            backgroundImageUrl: undefined
+        };
+    }
+    const unparsedBackgroundData = serializedBackgroundProperties.split('|');
+
+    return {
+        backgroundLastUpdate: unparsedBackgroundData[0],
+        backgroundColor: unparsedBackgroundData[1],
+        backgroundImageUrl: unparsedBackgroundData[2]
+    };
+}
+
+/**
+ * The function synchronizes the information between remote participants to make sure to get the latest
+ * background defined.
+ *
+ * @param {Object} participantsState - Participants redux state.
+ * @param {Object} conferenceState - Conference redux state.
+ * @private
+ * @returns {Object}
+ */
+export function getLatestBackground(participantsState, conferenceState) {
+
+    const remoteParticipants = participantsState
+        .filter(participant => !participant.local)
+        .map(p => (conferenceState?.participants || {})[p.id])
+        .map(p => extractBackgroundProperties(p?._properties?.backgroundData));
+
+    const participants = remoteParticipants
+        .filter(participant => participant.backgroundLastUpdate !== undefined);
+
+    const reference = participants
+        .sort((a, b) => parseInt(b.backgroundLastUpdate, 10) - parseInt(a.backgroundLastUpdate, 10))[0];
+
+    return {
+        backgroundColor: reference?.backgroundColor,
+        backgroundImageUrl: reference?.backgroundImageUrl
+    };
+}

--- a/react/features/room-background/functions.js
+++ b/react/features/room-background/functions.js
@@ -10,7 +10,6 @@
 export function extractBackgroundProperties(serializedBackgroundProperties) {
     if (!serializedBackgroundProperties) {
         return {
-            backgroundLastUpdate: undefined,
             backgroundColor: undefined,
             backgroundImageUrl: undefined
         };
@@ -18,8 +17,7 @@ export function extractBackgroundProperties(serializedBackgroundProperties) {
     const unparsedBackgroundData = serializedBackgroundProperties.split('|');
 
     return {
-        backgroundLastUpdate: unparsedBackgroundData[0],
-        backgroundColor: unparsedBackgroundData[1],
-        backgroundImageUrl: unparsedBackgroundData[2]
+        backgroundColor: unparsedBackgroundData[0],
+        backgroundImageUrl: unparsedBackgroundData[1]
     };
 }

--- a/react/features/room-background/functions.js
+++ b/react/features/room-background/functions.js
@@ -4,7 +4,6 @@
  * Extract background-relevant information if existing from serialized background properties.
  *
  * @param {Object} serializedBackgroundProperties - Serialized background properties ('|' separated).
- * @private
  * @returns {Object}
  */
 export function extractBackgroundProperties(serializedBackgroundProperties) {
@@ -20,4 +19,20 @@ export function extractBackgroundProperties(serializedBackgroundProperties) {
         backgroundColor: unparsedBackgroundData[0],
         backgroundImageUrl: unparsedBackgroundData[1]
     };
+}
+
+/**
+ * Returns a boolean describing whether a background is currently set or not.
+ *
+ * @param {Object} state - Redux state.
+ * @returns {boolean}
+ */
+export function isRoomBackgroundDefined(state: Object = {}) {
+    const roomBackgroundState = state['features/room-background'];
+
+    if (roomBackgroundState?.backgroundImageUrl || roomBackgroundState?.backgroundColor) {
+        return true;
+    }
+
+    return false;
 }

--- a/react/features/room-background/functions.js
+++ b/react/features/room-background/functions.js
@@ -6,7 +6,7 @@
  * @param {Object} serializedBackgroundProperties - Serialized background properties ('|' separated).
  * @returns {Object}
  */
-export function extractBackgroundProperties(serializedBackgroundProperties) {
+export function extractBackgroundProperties(serializedBackgroundProperties: String) {
     if (!serializedBackgroundProperties) {
         return {
             backgroundColor: undefined,

--- a/react/features/room-background/functions.js
+++ b/react/features/room-background/functions.js
@@ -23,31 +23,3 @@ export function extractBackgroundProperties(serializedBackgroundProperties) {
         backgroundImageUrl: unparsedBackgroundData[2]
     };
 }
-
-/**
- * The function synchronizes the information between remote participants to make sure to get the latest
- * background defined.
- *
- * @param {Object} participantsState - Participants redux state.
- * @param {Object} conferenceState - Conference redux state.
- * @private
- * @returns {Object}
- */
-export function getLatestBackground(participantsState, conferenceState) {
-
-    const remoteParticipants = participantsState
-        .filter(participant => !participant.local)
-        .map(p => (conferenceState?.participants || {})[p.id])
-        .map(p => extractBackgroundProperties(p?._properties?.backgroundData));
-
-    const participants = remoteParticipants
-        .filter(participant => participant.backgroundLastUpdate !== undefined);
-
-    const reference = participants
-        .sort((a, b) => parseInt(b.backgroundLastUpdate, 10) - parseInt(a.backgroundLastUpdate, 10))[0];
-
-    return {
-        backgroundColor: reference?.backgroundColor,
-        backgroundImageUrl: reference?.backgroundImageUrl
-    };
-}

--- a/react/features/room-background/index.js
+++ b/react/features/room-background/index.js
@@ -1,0 +1,2 @@
+export * from './actions';
+export * from './functions';

--- a/react/features/room-background/middleware.js
+++ b/react/features/room-background/middleware.js
@@ -1,0 +1,1 @@
+import './subscriber';

--- a/react/features/room-background/reducer.js
+++ b/react/features/room-background/reducer.js
@@ -1,0 +1,52 @@
+// @flow
+
+import { ReducerRegistry } from '../base/redux';
+
+import {
+    SET_BACKGROUND_DATA
+} from './actionTypes';
+
+/**
+ * The name of the redux store/state property which is the root of the redux
+ * state of the feature {@code room-background}.
+ */
+const STORE_NAME = 'features/room-background';
+
+const DEFAULT_STATE = {
+    /**
+     * The custom background color for the LargeVideo.
+     *
+     * @public
+     * @type {string}
+     */
+    backgroundColor: '',
+
+    /**
+     * The custom background image used on the LargeVideo.
+     *
+     * @public
+     * @type {string}
+     */
+    backgroundImageUrl: ''
+};
+
+/**
+ * Reduces redux actions for the purposes of the feature {@code room-background}.
+ */
+ReducerRegistry.register(STORE_NAME, (state = DEFAULT_STATE, action) => {
+    switch (action.type) {
+    case SET_BACKGROUND_DATA: {
+        const {
+            backgroundColor,
+            backgroundImageUrl
+        } = action.value;
+
+        return {
+            backgroundColor,
+            backgroundImageUrl
+        };
+    }
+    }
+
+    return state;
+});

--- a/react/features/room-background/subscriber.js
+++ b/react/features/room-background/subscriber.js
@@ -3,13 +3,16 @@
 import { getLocalParticipant } from '../base/participants';
 import { StateListenerRegistry } from '../base/redux';
 
+import {
+    resizeLargeVideo
+} from './../large-video';
 import { updateBackgroundData } from './actions';
 import { extractBackgroundProperties } from './functions';
 
 declare var APP: Object;
 
 /**
- * Updates the room background when participants updated
+ * Updates the room background when participants backgroundData property is updated
  */
 StateListenerRegistry.register(
     /* selector */ state => state['features/base/participants'],
@@ -40,5 +43,15 @@ StateListenerRegistry.register(
                     backgroundColor: backgroundProperties.backgroundColor
                 });
         }
+    }
+);
+
+/**
+ * When the background of the room is updated, resize the video.
+ */
+StateListenerRegistry.register(
+    /* selector */ state => state['features/room-background'],
+    /* listener */(state, { dispatch }) => {
+        dispatch(resizeLargeVideo());
     }
 );

--- a/react/features/room-background/subscriber.js
+++ b/react/features/room-background/subscriber.js
@@ -1,0 +1,44 @@
+// @flow
+
+import { getLocalParticipant } from '../base/participants';
+import { StateListenerRegistry } from '../base/redux';
+
+import { updateBackgroundData } from './actions';
+import { extractBackgroundProperties } from './functions';
+
+declare var APP: Object;
+
+/**
+ * Updates the room background when participants updated
+ */
+StateListenerRegistry.register(
+    /* selector */ state => state['features/base/participants'],
+    /* listener */(state, { dispatch }, previousState) => {
+
+        if (!state.length) {
+            return;
+        }
+
+        const localParticipant = getLocalParticipant(state);
+        const backgroundData = localParticipant?.backgroundData;
+
+        if (backgroundData === getLocalParticipant(previousState)?.backgroundData) {
+            return;
+        }
+
+        // Updating the background of the room
+        dispatch(updateBackgroundData(backgroundData));
+
+        // Sending an event to the client to communicate the background change
+        if (typeof APP !== 'undefined') {
+            const backgroundProperties = extractBackgroundProperties(backgroundData);
+
+            APP.API.notifyBackgroundChanged(
+                localParticipant.id,
+                {
+                    backgroundImageUrl: backgroundProperties.backgroundImageUrl,
+                    backgroundColor: backgroundProperties.backgroundColor
+                });
+        }
+    }
+);

--- a/react/features/room-background/subscriber.js
+++ b/react/features/room-background/subscriber.js
@@ -4,7 +4,7 @@ import { getLocalParticipant } from '../base/participants';
 import { StateListenerRegistry } from '../base/redux';
 
 import {
-    resizeLargeVideo
+    refreshResizingLargeVideo
 } from './../large-video';
 import { updateBackgroundData } from './actions';
 import { extractBackgroundProperties } from './functions';
@@ -52,6 +52,6 @@ StateListenerRegistry.register(
 StateListenerRegistry.register(
     /* selector */ state => state['features/room-background'],
     /* listener */(state, { dispatch }) => {
-        dispatch(resizeLargeVideo());
+        dispatch(refreshResizingLargeVideo(true));
     }
 );


### PR DESCRIPTION
## Description of the PR

This PR provides a way to set a background image/color for a room via an external API call.

## Type of change

* [ ] Technical
* [x] Feature
* [ ] Documentation
* [ ] Bugfix

## Screenshots

https://user-images.githubusercontent.com/79834730/110825011-e5ac2680-8293-11eb-8b44-d962346716a4.mp4

## Checklist

- [x] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [x] : PR ready for reviews

## Issues to clarify before merge

- [x] : What should happen for a new coming participant? Should we have a mechanism to set the background of the room for him/her as well? **Yes. Has been implemented**
- [x] : The background seems to be updated only when the mouse is over the discussion. Is there some known properties of Jitsi Meet regarding that? Can we else manually trigger a UI update? **This has been solved when going from a "full" state approach to an event-driven approach.**
- [x] : The participant informed about a change in the background should update its local copy of the background and the conference copy. This would prevent a leaving user to make the conference lose the background property. **It has been implemented.**
- [x] : Is it possible to use setLocalProperty to set multiple properties at once? This would avoid triggering multiple update of the conference state. > **Properties have been serialized to minimize the data transfer**
- [x] : Reduce the video size in "speaker view" mode in order to be able to see the background if a background is defined. **This has been implemented. The ratio is for now hard-coded.**
- [x] : Avoid reloading the background information if multiple participants are simultaneously setting the same background information. **This has been implemented. Every incoming requests trying to set the background data to the same value will now be ignored.**
- [x] : Adding a notification event in the external API to inform the client that a background has been set. **This is implemented. An event roomBackgroundUpdated is sent once the local participant has updated its background.**
- [x] : Can the participant set a background before entering the room (before clicking "Join Meeting" in native Jitsi Meet)? **Response : This should not be possible. The implementation has been corrected to prevent this case from happening.**