### PR TITLE
Adding a retry button to capture again the local video track

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.9] - 2021-04-13
+## Added
+- Option enabling for the user to retry when the access to the camera failed
+
+## Fixed
+- Camera error notification also displayed in case of 1+ access to the camera
+
 ## [1.1.8] - 2021-04-09
 ### Added
 - Documentation for contributions and deployment process

--- a/conference.js
+++ b/conference.js
@@ -1009,7 +1009,23 @@ export default {
                 .then(([ videoTrack ]) => videoTrack)
                 .catch(error => {
                     // FIXME should send some feedback to the API on error ?
-                    maybeShowErrorDialog(error);
+
+                    // Retrying to capture video track only if the video is still muted
+                    if (!mute) {
+                        const errorAndRetry = {
+                            ...error,
+                            customActionNameKey: 'dialog.retry',
+                            customActionHandler: () => {
+                                if (this.isLocalVideoMuted()) {
+                                    this.muteVideo(mute, showUI);
+                                }
+
+                                return true;
+                            }
+                        };
+
+                        maybeShowErrorDialog(errorAndRetry);
+                    }
 
                     // Rollback the video muted status by using null track
                     return null;

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -171,7 +171,7 @@ function initCommands() {
         'toggle-video': () => {
             sendAnalytics(createApiEvent('toggle-video'));
             logger.log('Video toggle: API command received');
-            APP.conference.toggleVideoMuted(false /* no UI */);
+            APP.conference.toggleVideoMuted(true /* no UI */);
         },
         'toggle-film-strip': () => {
             sendAnalytics(createApiEvent('film.strip.toggled'));

--- a/react/features/base/devices/actions.js
+++ b/react/features/base/devices/actions.js
@@ -158,6 +158,8 @@ export function getAvailableDevices() {
  * @param {string} error.name - The constant for the type of the error.
  * @param {string} error.message - Optional additional information about the
  * error.
+ * @param {string} error.customActionNameKey - Optional action name linked with the notification.
+ * @param {Function} error.customActionHandler - Optional function corresponding to the action.
  * @returns {{
  *     type: NOTIFY_CAMERA_ERROR,
  *     error: Object

--- a/react/features/base/devices/middleware.js
+++ b/react/features/base/devices/middleware.js
@@ -2,7 +2,7 @@
 
 import UIEvents from '../../../../service/UI/UIEvents';
 import { processExternalDeviceRequest } from '../../device-selection';
-import { showNotification, showWarningNotification } from '../../notifications';
+import { showNotification, showWarningNotification, showUnreachableNotification } from '../../notifications';
 import { replaceAudioTrackById, replaceVideoTrackById, setDeviceStatusWarning } from '../../prejoin/actions';
 import { isPrejoinPageVisible } from '../../prejoin/functions';
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../app';
@@ -131,7 +131,7 @@ MiddlewareRegistry.register(store => next => action => {
         const titleKey = name === JitsiTrackErrors.PERMISSION_DENIED
             ? 'deviceError.cameraPermission' : 'deviceError.cameraError';
 
-        store.dispatch(showWarningNotification({
+        store.dispatch(showUnreachableNotification({
             description: additionalCameraErrorMsg,
             descriptionKey: cameraErrorMsg,
             titleKey,

--- a/react/features/base/devices/middleware.js
+++ b/react/features/base/devices/middleware.js
@@ -119,6 +119,8 @@ MiddlewareRegistry.register(store => next => action => {
         }
 
         const { message, name } = action.error;
+        const customActionNameKey = action.error?.customActionNameKey;
+        const customActionHandler = action.error?.customActionHandler;
 
         const cameraJitsiTrackErrorMsg
                 = JITSI_TRACK_ERROR_TO_MESSAGE_KEY_MAP.camera[name];
@@ -132,7 +134,9 @@ MiddlewareRegistry.register(store => next => action => {
         store.dispatch(showWarningNotification({
             description: additionalCameraErrorMsg,
             descriptionKey: cameraErrorMsg,
-            titleKey
+            titleKey,
+            customActionNameKey,
+            customActionHandler
         }));
 
         if (isPrejoinPageVisible(store.getState())) {

--- a/react/features/base/tracks/functions.js
+++ b/react/features/base/tracks/functions.js
@@ -1,5 +1,8 @@
 /* global APP */
 
+import {
+    notifyCameraError
+} from '../devices';
 import JitsiMeetJS, { JitsiTrackErrors, browser } from '../lib-jitsi-meet';
 import { MEDIA_TYPE, VIDEO_TYPE, setAudioMuted } from '../media';
 import {
@@ -472,6 +475,18 @@ export function setTrackMuted(track, muted) {
         if (error.name !== JitsiTrackErrors.TRACK_IS_DISPOSED) {
             // FIXME Emit mute failed, so that the app can show error dialog.
             logger.error(`set track ${f} failed`, error);
+
+            const showUI = true;
+            const maybeShowErrorDialog = errorObject => {
+                showUI && APP.store.dispatch(notifyCameraError(errorObject));
+            };
+            const errorAndRetry = {
+                ...error,
+                customActionNameKey: 'dialog.retry',
+                customActionHandler: () => APP.conference.toggleVideoMuted(showUI)
+            };
+
+            maybeShowErrorDialog(errorAndRetry);
         }
     });
 }

--- a/react/features/notifications/actions.js
+++ b/react/features/notifications/actions.js
@@ -120,7 +120,7 @@ export function showWarningNotification(props: Object) {
  * @param {Object} props - The props needed to show the notification component.
  * @returns {Object}
  */
- export function showUnreachableNotification(props: Object) {
+export function showUnreachableNotification(props: Object) {
     return showNotification({
         ...props,
         appearance: NOTIFICATION_TYPE.UNREACHABLE

--- a/react/features/notifications/actions.js
+++ b/react/features/notifications/actions.js
@@ -110,7 +110,7 @@ export function showNotification(props: Object = {}, timeout: ?number) {
 export function showWarningNotification(props: Object) {
     return showNotification({
         ...props,
-        appearance: NOTIFICATION_TYPE.WARNING
+        appearance: NOTIFICATION_TYPE.NORMAL
     });
 }
 

--- a/react/features/notifications/actions.js
+++ b/react/features/notifications/actions.js
@@ -110,7 +110,20 @@ export function showNotification(props: Object = {}, timeout: ?number) {
 export function showWarningNotification(props: Object) {
     return showNotification({
         ...props,
-        appearance: NOTIFICATION_TYPE.NORMAL
+        appearance: NOTIFICATION_TYPE.WARNING
+    });
+}
+
+/**
+ * Queues an unreachable notification for display.
+ *
+ * @param {Object} props - The props needed to show the notification component.
+ * @returns {Object}
+ */
+ export function showUnreachableNotification(props: Object) {
+    return showNotification({
+        ...props,
+        appearance: NOTIFICATION_TYPE.UNREACHABLE
     });
 }
 

--- a/react/features/notifications/components/web/Notification.js
+++ b/react/features/notifications/components/web/Notification.js
@@ -125,14 +125,26 @@ class Notification extends AbstractNotification<Props> {
 
             return buttons;
         }
-        case NOTIFICATION_TYPE.WARNING:
-            return [
+        case NOTIFICATION_TYPE.WARNING: {
+            const buttons = [
                 {
                     content: this.props.t('dialog.Ok'),
                     onClick: this._onDismissed
                 }
             ];
 
+            if (this.props.customActionNameKey && this.props.customActionHandler) {
+                buttons.push({
+                    content: this.props.t(this.props.customActionNameKey),
+                    onClick: () => {
+                        this.props.customActionHandler();
+                        this._onDismissed();
+                    }
+                });
+            }
+
+            return buttons;
+        }
         default:
             if (this.props.customActionNameKey && this.props.customActionHandler) {
                 return [

--- a/react/features/notifications/components/web/Notification.js
+++ b/react/features/notifications/components/web/Notification.js
@@ -1,10 +1,10 @@
 // @flow
 
 import Flag from '@atlaskit/flag';
+import CrossCircleIcon from '@atlaskit/icon/glyph/cross-circle';
 import EditorInfoIcon from '@atlaskit/icon/glyph/editor/info';
 import ErrorIcon from '@atlaskit/icon/glyph/error';
 import WarningIcon from '@atlaskit/icon/glyph/warning';
-import CrossCircleIcon from '@atlaskit/icon/glyph/cross-circle';
 import { colors } from '@atlaskit/theme';
 import React from 'react';
 
@@ -101,17 +101,19 @@ class Notification extends AbstractNotification<Props> {
 
     /**
      * Gives back a native appearance type if the appearance requested is not existing
-     * for the Flag component
+     * for the Flag component.
      *
-     * @param {string} appearance - Requested appearance
+     * @param {string} appearance - Requested appearance.
      * @private
      * @returns {string}
      */
-    _getResolvedAppearance(appearance){
-        const nativeAppearances = ['error','info','success','normal','warning']
-        if(nativeAppearances.includes(appearance)){
+    _getResolvedAppearance(appearance) {
+        const nativeAppearances = [ 'error', 'info', 'success', 'normal', 'warning' ];
+
+        if (nativeAppearances.includes(appearance)) {
             return appearance;
         }
+
         return 'normal';
     }
 

--- a/react/features/notifications/components/web/Notification.js
+++ b/react/features/notifications/components/web/Notification.js
@@ -4,6 +4,7 @@ import Flag from '@atlaskit/flag';
 import EditorInfoIcon from '@atlaskit/icon/glyph/editor/info';
 import ErrorIcon from '@atlaskit/icon/glyph/error';
 import WarningIcon from '@atlaskit/icon/glyph/warning';
+import CrossCircleIcon from '@atlaskit/icon/glyph/cross-circle';
 import { colors } from '@atlaskit/theme';
 import React from 'react';
 
@@ -34,6 +35,7 @@ const ICON_COLOR = {
  * @extends Component
  */
 class Notification extends AbstractNotification<Props> {
+
     /**
      * Implements React's {@link Component#render()}.
      *
@@ -54,7 +56,7 @@ class Notification extends AbstractNotification<Props> {
         return (
             <Flag
                 actions = { this._mapAppearanceToButtons(hideErrorSupportLink) }
-                appearance = { appearance }
+                appearance = { this._getResolvedAppearance(appearance) }
                 description = { this._renderDescription() }
                 icon = { this._mapAppearanceToIcon() }
                 id = { uid }
@@ -95,6 +97,22 @@ class Notification extends AbstractNotification<Props> {
      */
     _onOpenSupportLink() {
         window.open(interfaceConfig.SUPPORT_URL, '_blank', 'noopener');
+    }
+
+    /**
+     * Gives back a native appearance type if the appearance requested is not existing
+     * for the Flag component
+     *
+     * @param {string} appearance - Requested appearance
+     * @private
+     * @returns {string}
+     */
+    _getResolvedAppearance(appearance){
+        const nativeAppearances = ['error','info','success','normal','warning']
+        if(nativeAppearances.includes(appearance)){
+            return appearance;
+        }
+        return 'normal';
     }
 
     /**
@@ -191,7 +209,13 @@ class Notification extends AbstractNotification<Props> {
                     secondaryColor = { secIconColor }
                     size = { iconSize } />
             );
-
+        case NOTIFICATION_TYPE.UNREACHABLE:
+            return (
+                <CrossCircleIcon
+                    label = { appearance }
+                    secondaryColor = { secIconColor }
+                    size = { iconSize } />
+            );
         default:
             return (
                 <EditorInfoIcon

--- a/react/features/notifications/constants.js
+++ b/react/features/notifications/constants.js
@@ -15,7 +15,8 @@ export const NOTIFICATION_TYPE = {
     INFO: 'info',
     NORMAL: 'normal',
     SUCCESS: 'success',
-    WARNING: 'warning'
+    WARNING: 'warning',
+    UNREACHABLE: 'unreachable'
 };
 
 /**


### PR DESCRIPTION
## Description of the PR

When the camera device cannot be captured, the notification displayed to the user should contain a button enabling to retry. The initial goal is to fully automatize this process. Unfortunately, this is currently not feasible with the current state of the low level API consumed by the app. 

This includes a correction of the bug :
* no error dialog was available on 1+ access to the camera

Remaining issue :
* multiple unexpected behavior with Firefox that have already been identified before.

## Type of change

* [ ] : Technical
* [x] : Feature
* [ ] : Documentation
* [ ] : Bugfix

## Screenshots

https://user-images.githubusercontent.com/79834730/112495121-e52b8980-8d83-11eb-8f31-d8af460f9d1f.mp4

## Checklist

- [x] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [x] : PR ready for reviews

## Issues to clarify before merge

- [x] : Is there a preferred solution for this issue? **Implement the notification so that the notification is directly expanded and the retry button is visible** > Issue : Possible implementations limited by implementation of Flag in Atlaskit : Either we currently give up on warning/error style or we let the retry button hidden : https://atlassian.design/components/flag/examples > Decision : We implement with a not-warning style notification.