### PR TITLE
Adding command to acquire speaker stats at a specific timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.11] - 2021-04-15
+### Added
+- External API commands to access speaker stats
+- Possibility to request either once or at multiple intervals the speaker stats
+
 ## [1.1.10] - 2021-04-15
 ### Fixed
 - Restoring linux compatibility for build commands

--- a/doc/ivicos/api-doc.md
+++ b/doc/ivicos/api-doc.md
@@ -78,31 +78,18 @@ api.addListener('foregroundOverlayUpdated', (e) => {
 
 A toolbar button can also be used in order to trigger the command. The corresponding ID is 'select-foreground-overlay'.
 
-## getSpeakerStats (coming soon)
+## getSpeakerStats
 
 ### Description
 
 The command enables to get via API command the speaker statistics given back as a JSON object.
-The user can either request the statistics once or at a regular interval.
+This command can be used to request the statistics once.
+It is possible to collect speaker stats at regular interval with the command `startCollectSpeakerStats` introduced after.
 
 ### Usage
 
-#### General
-
-```
-api.getSpeakerStats(intervalRequest) # intervalRequest being optional, in ms when given
-```
-
-#### One-time request
-
 ```
 api.getSpeakerStats()
-```
-
-#### 1s-spaced requests
-
-```
-api.getSpeakerStats(1000)
 ```
 
 ### Notification event
@@ -111,6 +98,57 @@ A notification event is sent back to the local participant with the speaker stat
 
 ```
 api.addListener('speakerStatsUpdated', (e) => {
+	console.log(e);
+});
+```
+
+## startCollectSpeakerStats
+
+### Description
+
+The command enables to start collecting speaker statistics at a regular interval.
+
+### Usage
+
+```
+api.startCollectSpeakerStats(intervalRequest)
+```
+* `intervalRequest` : time interval (in ms) between two requests, default is 1000ms
+
+### Notification event
+
+A notification event is sent back to the local participant with the speaker statistics once collected. In order to catch this event, the following code can be used. The event contains the speaker stats requested by the user :
+
+```
+api.addListener('speakerStatsUpdated', (e) => {
+	console.log(e);
+});
+```
+
+It is also possible to check whether the original command has been received successfully with :
+```
+api.addListener('speakerStatsCollectStarted', (e) => {
+	console.log(e);
+});
+```
+
+## stopCollectSpeakerStats
+
+### Description
+
+The command enables to stop collecting speaker statistics (if existing).
+
+### Usage
+
+```
+api.stopCollectSpeakerStats()
+```
+
+### Notification event
+
+It is  possible to check whether the stopping command has been received successfully with :
+```
+api.addListener('speakerStatsCollectStopped', (e) => {
 	console.log(e);
 });
 ```

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -33,6 +33,8 @@ const commands = {
     e2eeKey: 'e2ee-key',
     email: 'email',
     toggleLobby: 'toggle-lobby',
+    getSpeakerStats: 'get-speaker-stats',
+    stopSpeakerStats: 'stop-speaker-stats',
     hangup: 'video-hangup',
     intiatePrivateChat: 'initiate-private-chat',
     kickParticipant: 'kick-participant',
@@ -93,6 +95,9 @@ const events = {
     'raise-hand-updated': 'raiseHandUpdated',
     'recording-status-changed': 'recordingStatusChanged',
     'room-background-updated': 'roomBackgroundUpdated',
+    'speaker-stats-collect-started': 'speakerStatsCollectStarted',
+    'speaker-stats-collect-stopped': 'speakerStatsCollectStopped',
+    'speaker-stats-updated': 'speakerStatsUpdated',
     'video-ready-to-close': 'readyToClose',
     'video-conference-joined': 'videoConferenceJoined',
     'video-conference-left': 'videoConferenceLeft',
@@ -1144,5 +1149,33 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
             overlayColor,
             mode
         );
+    }
+
+    /**
+     * Get speaker statistics for the room.
+     *
+     * @returns {void}
+     */
+    getSpeakerStats() {
+        this.executeCommand('getSpeakerStats', false, 0);
+    }
+
+    /**
+     * Start collecting speaker stats.
+     *
+     * @param { number } intervalRequest - Interval (ms) between each speaker stats notification.
+     * @returns {void}
+     */
+    startCollectSpeakerStats(intervalRequest = 1000) {
+        this.executeCommand('getSpeakerStats', true, intervalRequest);
+    }
+
+    /**
+     * Stop collecting speaker stats.
+     *
+     * @returns {void}
+     */
+    stopCollectSpeakerStats() {
+        this.executeCommand('stopSpeakerStats');
     }
 }

--- a/react/features/app/reducers.any.js
+++ b/react/features/app/reducers.any.js
@@ -45,6 +45,7 @@ import '../recent-list/reducer';
 import '../recording/reducer';
 import '../room-background/reducer';
 import '../settings/reducer';
+import '../speaker-stats/reducer';
 import '../subtitles/reducer';
 import '../toolbox/reducer';
 import '../transcribing/reducer';

--- a/react/features/speaker-stats/actionTypes.js
+++ b/react/features/speaker-stats/actionTypes.js
@@ -1,0 +1,4 @@
+/**
+ * Action used to configure the speaker stats related events
+ */
+export const CONFIGURE_SPEAKER_STATS_COLLECT = 'CONFIGURE_SPEAKER_STATS_COLLECT';

--- a/react/features/speaker-stats/actions.js
+++ b/react/features/speaker-stats/actions.js
@@ -1,0 +1,91 @@
+// @flow
+
+import type { Dispatch } from 'redux';
+
+import {
+    CONFIGURE_SPEAKER_STATS_COLLECT
+} from './actionTypes';
+import {
+    clearSpeakerStatsInterval,
+    createSpeakerStatsInterval,
+    fetchDetailedSpeakerStats
+} from './functions';
+
+declare var APP: Object;
+
+/**
+ * Fetch speaker stats and send them back to the client.
+ *
+ * @returns {void}
+ */
+export function getSpeakerStats() {
+    fetchDetailedSpeakerStats();
+}
+
+/**
+ * Action triggering timer to regularly collect speaker stats at a regular interval.
+ *
+ * @param {number} intervalRequest - Interval between two consecutive request (ms).
+ * @returns {Function}
+ */
+export function startSpeakerStatsCollect(intervalRequest: number) {
+    APP.API.notifySpeakerStatsCollectStarted(intervalRequest);
+
+    return async (dispatch: Dispatch<any>, getState: Function) => {
+        const state = getState()['features/speaker-stats'];
+
+        clearSpeakerStatsInterval(state?.repeatedStatsRequest);
+        const repeatedStatsRequest = createSpeakerStatsInterval(intervalRequest);
+
+        if (repeatedStatsRequest) {
+            dispatch(updateSpeakerStatsState({
+                repeatedStatsRequest,
+                intervalMs: intervalRequest
+            }));
+        }
+    };
+}
+
+/**
+ * Action stopping the timer regularly collecting speaker stats at a regular interval.
+ *
+ * @returns {Function}
+ */
+export function stopSpeakerStatsCollect() {
+    APP.API.notifySpeakerStatsCollectStopped();
+
+    return async (dispatch: Dispatch<any>, getState: Function) => {
+        const state = getState()['features/speaker-stats'];
+
+        clearSpeakerStatsInterval(state?.repeatedStatsRequest);
+        dispatch(clearSpeakerStatsState());
+    };
+}
+
+/**
+ * Action used to update the configuration for the speaker stats event.
+ *
+ * @param {Object} value - The custom data to be set.
+ * @returns {Object}
+ */
+function updateSpeakerStatsState(value) {
+    return {
+        type: CONFIGURE_SPEAKER_STATS_COLLECT,
+        value
+    };
+}
+
+/**
+ * Action used to clear the configuration for the speaker stats event.
+ *
+ * @returns {Object}
+ */
+function clearSpeakerStatsState() {
+    return {
+        type: CONFIGURE_SPEAKER_STATS_COLLECT,
+        value: {
+            repeatedStatsRequest: undefined,
+            intervalMs: undefined
+        }
+    };
+}

--- a/react/features/speaker-stats/functions.js
+++ b/react/features/speaker-stats/functions.js
@@ -1,0 +1,44 @@
+// @flow
+
+declare var APP: Object;
+
+/**
+ * Clears the speaker stats requests with a specific timer ID.
+ *
+ * @param {Object} timerId - ID of the timer to be cleared.
+ * @returns {void}
+ */
+export function clearSpeakerStatsInterval(timerId: Object) {
+    if (timerId) {
+        clearInterval(timerId);
+    }
+}
+
+/**
+ * Creates a timer to perform repeated requests to get speaker stats.
+ *
+ * @param {number} intervalRequest - Interval between two consecutive request (ms).
+ * @returns {Object} - ID of the corresponding timer.
+ */
+export function createSpeakerStatsInterval(intervalRequest: number) {
+    return setInterval(fetchDetailedSpeakerStats, intervalRequest);
+}
+
+/**
+ * Fetch speaker stats and send them back to the client.
+ *
+ * @returns {void}
+ */
+export function fetchDetailedSpeakerStats() {
+    const stats = APP.conference.getSpeakerStats();
+    const userIds = Object.keys(stats);
+    const speakerTimeList = userIds.map(userId => {
+        return {
+            userId,
+            userName: stats[userId].displayName,
+            speakerTime: stats[userId].getTotalDominantSpeakerTime()
+        };
+    });
+
+    APP.API.notifySpeakerStatsReceived(speakerTimeList);
+}

--- a/react/features/speaker-stats/index.js
+++ b/react/features/speaker-stats/index.js
@@ -1,1 +1,3 @@
 export * from './components';
+export * from './actions';
+export * from './functions';

--- a/react/features/speaker-stats/reducer.js
+++ b/react/features/speaker-stats/reducer.js
@@ -1,0 +1,52 @@
+// @flow
+
+import { ReducerRegistry } from '../base/redux';
+
+import {
+    CONFIGURE_SPEAKER_STATS_COLLECT
+} from './actionTypes';
+
+/**
+ * The name of the redux store/state property which is the root of the redux
+ * state of the feature {@code speaker-stats}.
+ */
+const STORE_NAME = 'features/speaker-stats';
+
+const DEFAULT_STATE = {
+    /**
+     * Repeated speaker stats interval object
+     *
+     * @public
+     * @type {Function}
+     */
+    repeatedStatsRequest: undefined,
+
+    /**
+     * Interval of the repeated request (ms)
+     *
+     * @public
+     * @type {number}
+     */
+    intervalMs: undefined
+};
+
+/**
+ * Reduces redux actions for the purposes of the feature {@code speaker-stats}.
+ */
+ReducerRegistry.register(STORE_NAME, (state = DEFAULT_STATE, action) => {
+    switch (action.type) {
+    case CONFIGURE_SPEAKER_STATS_COLLECT: {
+        const {
+            repeatedStatsRequest,
+            intervalMs
+        } = action.value;
+
+        return {
+            repeatedStatsRequest,
+            intervalMs
+        };
+    }
+    }
+
+    return state;
+});


### PR DESCRIPTION
## Description of the PR

Adding command to acquire speaker stats at a specific timing.
If possible, make it possible to automatically request speaker stats at regular interval.

## Type of change

* [ ] : Technical
* [x] : Feature
* [ ] : Documentation
* [ ] : Bugfix

## Screenshots

https://user-images.githubusercontent.com/79834730/113880716-0183e900-97bc-11eb-9707-7b4bc0b3b413.mp4

## Checklist

- [x] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [x] : PR ready for reviews

## Issues to clarify before merge

- [x] Currently, it is possible to get speaker stats at a regular interval. However it s not possible to stop requesting the speaker stats or change the interval interactively. Should we support advanced management like this? > It has been decided that this should be the case : The management (stop, start, modify) should be possible.