### PR TITLE
Adding notification event when foreground overlay is being set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.5] - 2021-04-07
+## Added
+- Notify the client when a new foreground overlay is being set
+
 ## [1.1.4] - 2021-03-30
 ## Added
 - Removing versioning for bundle files in import

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1196,6 +1196,23 @@ class API {
     }
 
     /**
+     * Notify external application (if API is enabled) that user updated its foreground overlay information.
+     *
+     * @param {string} overlayImageUrl - URL of the overlay image.
+     * @param {string} overlayColor - Color code of the overlay.
+     * @param {string} mode - Combination mode of the overlay.
+     * @returns {void}
+     */
+    notifyForegroundOverlayChanged(overlayImageUrl: string, overlayColor: string, mode: string) {
+        this._sendEvent({
+            name: 'foreground-overlay-updated',
+            overlayImageUrl,
+            overlayColor,
+            mode
+        });
+    }
+
+    /**
      * Disposes the allocated resources.
      *
      * @returns {void}

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -79,6 +79,7 @@ const events = {
     'feedback-submitted': 'feedbackSubmitted',
     'feedback-prompt-displayed': 'feedbackPromptDisplayed',
     'filmstrip-display-changed': 'filmstripDisplayChanged',
+    'foreground-overlay-updated': 'foregroundOverlayUpdated',
     'incoming-message': 'incomingMessage',
     'log': 'log',
     'mic-error': 'micError',

--- a/react/features/app/middlewares.any.js
+++ b/react/features/app/middlewares.any.js
@@ -29,6 +29,7 @@ import '../display-name/middleware';
 import '../etherpad/middleware';
 import '../filmstrip/middleware';
 import '../follow-me/middleware';
+import '../foreground-overlay/middleware';
 import '../invite/middleware';
 import '../large-video/middleware';
 import '../lobby/middleware';

--- a/react/features/app/reducers.any.js
+++ b/react/features/app/reducers.any.js
@@ -34,6 +34,7 @@ import '../dynamic-branding/reducer';
 import '../etherpad/reducer';
 import '../filmstrip/reducer';
 import '../follow-me/reducer';
+import '../foreground-overlay/reducer';
 import '../google-api/reducer';
 import '../invite/reducer';
 import '../large-video/reducer';

--- a/react/features/foreground-overlay/middleware.js
+++ b/react/features/foreground-overlay/middleware.js
@@ -1,0 +1,1 @@
+import './subscriber';

--- a/react/features/foreground-overlay/subscriber.js
+++ b/react/features/foreground-overlay/subscriber.js
@@ -1,0 +1,23 @@
+// @flow
+
+import { StateListenerRegistry } from '../base/redux';
+
+declare var APP: Object;
+
+/**
+ * Send an event when the foreground overlay has been changed
+ */
+StateListenerRegistry.register(
+    /* selector */ state => state['features/foreground-overlay'],
+    /* listener */state => {
+
+        if (typeof APP !== 'undefined') {
+            APP.API.notifyForegroundOverlayChanged(
+                {
+                    overlayImageUrl: state.overlayImageUrl,
+                    overlayColor: state.overlayColor,
+                    mode: state.mode
+                });
+        }
+    }
+);


### PR DESCRIPTION
## Description of the PR

Adding notification event when foreground overlay is being set

## Type of change

* [ ] : Technical
* [x] : Feature
* [ ] : Documentation
* [ ] : Bugfix

## Screenshots

<!-- Screenshots -->

## Checklist

- [x] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [x] : PR ready for reviews

## Issues to clarify before merge

- None