### PR TITLE
Test/noisegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.13] - 2021-04-26
+### Added
+- Enable console.log for volume, oldVolume and newVolume values.
 ## [1.1.12] - 2021-04-26
 ### Added
 - NoiseGate Effect created using the Thumbnails volume and the current audioLevel of each remote participant.

--- a/react/features/stream-effects/noisegate/index.js
+++ b/react/features/stream-effects/noisegate/index.js
@@ -14,6 +14,9 @@ export function createNoiseGateProcessor(audioLevel: number) {
     console.log('VOLUME');
     console.log(volume);
 
+    console.log('AUDIO LEVEL');
+    console.log(audioLevel);
+
     if (audioLevel <= 0.07) {
         const reductedVolume = oldVolume - 0.1;
 

--- a/react/features/stream-effects/noisegate/index.js
+++ b/react/features/stream-effects/noisegate/index.js
@@ -11,6 +11,9 @@ export function createNoiseGateProcessor(audioLevel: number) {
     const oldVolume: number = volume;
     let newVolume: number = 0;
 
+    console.log('VOLUME');
+    console.log(volume);
+
     if (audioLevel <= 0.07) {
         const reductedVolume = oldVolume - 0.1;
 
@@ -32,10 +35,10 @@ export function createNoiseGateProcessor(audioLevel: number) {
 
     volume = newVolume;
 
-    // console.log('FIRST VOLUME');
-    // console.log(oldVolume);
-    // console.log('NEW VOLUME');
-    // console.log(newVolume);
+    console.log('OLD VOLUME');
+    console.log(oldVolume);
+    console.log('NEW VOLUME');
+    console.log(newVolume);
 
     return newVolume;
 }


### PR DESCRIPTION
## Description of the PR

Enable console.log for 'volume', 'oldVolume' and ' newVolume' values, to check if noisegate is processing and if the "volume" variable (out of the "createNoiseGateProcessor) is being modified properly.

## Type of change

* [ ] : Technical
* [ ] : Feature
* [ ] : Documentation
* [x] : Bugfix

## Screenshots

<!-- Screenshots -->

## Checklist

- [ ] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [x] : PR ready for reviews

## Issues to clarify before merge

- [ ] Issue