### PR TITLE
Feature/get audio level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.14] - 2021-04-28
+### Added
+- Skip createNoiseGateProcessor and console.log 'audioLevel' and 'volume', to double check if even skipping the noise gate the audioLevel is 0.
 ## [1.1.13] - 2021-04-26
 ### Added
 - Enable console.log for volume, oldVolume and newVolume values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.13] - 2021-04-26
+### Added
+- Enable console.log for volume, oldVolume and newVolume values.
 ## [1.1.12] - 2021-04-26
 ### Added
 - NoiseGate Effect created using the Thumbnails volume and the current audioLevel of each remote participant.

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -805,7 +805,8 @@ class Thumbnail extends Component<Props, State> {
         } = this.props;
         const { id } = _participant;
         const { audioLevel, canPlayEventReceived, volume } = this.state;
-        const newVolume = createNoiseGateProcessor(audioLevel);
+
+        // const newVolume = createNoiseGateProcessor(audioLevel);
         const styles = this._getStyles();
         const containerClassName = this._getContainerClassName();
 
@@ -829,6 +830,11 @@ class Thumbnail extends Component<Props, State> {
             display: 'none'
         };
 
+        console.log('AUDIO LEVEL');
+        console.log(audioLevel);
+        console.log('VOLUME');
+        console.log(volume);
+
         return (
             <span
                 className = { containerClassName }
@@ -851,7 +857,7 @@ class Thumbnail extends Component<Props, State> {
                         id = { `remoteAudio_${audioTrackId || ''}` }
                         muted = { _startSilent }
                         onInitialVolumeSet = { this._onInitialVolumeSet }
-                        volume = { newVolume } />
+                        volume = { volume } />
                 }
                 <div className = 'videocontainer__background' />
                 <div className = 'videocontainer__toptoolbar'>

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -26,7 +26,6 @@ import { ConnectionIndicator } from '../../../connection-indicator';
 import { DisplayName } from '../../../display-name';
 import { StatusIndicators, RaisedHandIndicator, DominantSpeakerIndicator } from '../../../filmstrip';
 import { PresenceLabel } from '../../../presence-status';
-import { createNoiseGateProcessor } from '../../../stream-effects/noisegate';
 import { getCurrentLayout, LAYOUTS } from '../../../video-layout';
 import { LocalVideoMenuTriggerButton, RemoteVideoMenuTriggerButton } from '../../../video-menu';
 import {
@@ -38,6 +37,8 @@ import {
 } from '../../constants';
 import { isVideoPlayable, computeDisplayMode } from '../../functions';
 import logger from '../../logger';
+
+// import { createNoiseGateProcessor } from '../../../stream-effects/noisegate';
 
 const JitsiTrackEvents = JitsiMeetJS.events.track;
 

--- a/react/features/stream-effects/noisegate/index.js
+++ b/react/features/stream-effects/noisegate/index.js
@@ -14,6 +14,9 @@ export function createNoiseGateProcessor(audioLevel: number) {
     console.log('VOLUME');
     console.log(volume);
 
+    console.log('AUDIO LEVEL');
+    console.log(audioLevel);
+
     if (audioLevel <= 0.07) {
         const reductedVolume = oldVolume - 0.1;
 

--- a/react/features/stream-effects/noisegate/index.js
+++ b/react/features/stream-effects/noisegate/index.js
@@ -11,6 +11,9 @@ export function createNoiseGateProcessor(audioLevel: number) {
     const oldVolume: number = volume;
     let newVolume: number = 0;
 
+    console.log('VOLUME');
+    console.log(volume);
+
     if (audioLevel <= 0.07) {
         const reductedVolume = oldVolume - 0.1;
 
@@ -32,10 +35,10 @@ export function createNoiseGateProcessor(audioLevel: number) {
 
     volume = newVolume;
 
-    // console.log('FIRST VOLUME');
-    // console.log(oldVolume);
-    // console.log('NEW VOLUME');
-    // console.log(newVolume);
+    console.log('OLD VOLUME');
+    console.log(oldVolume);
+    console.log('NEW VOLUME');
+    console.log(newVolume);
 
     return newVolume;
 }


### PR DESCRIPTION
## Description of the PR

Skip createNoiseGateProcessor and console.log 'audioLevel' and 'volume' from Thumbnail.js, to double check if even without the noisegate audioLevel is still 0.

## Type of change

* [ ] : Technical
* [ ] : Feature
* [ ] : Documentation
* [x] : Bugfix

## Screenshots

<!-- Screenshots -->

## Checklist

- [ ] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [x] : PR ready for reviews

## Issues to clarify before merge

- [ ] Issue