### PR TITLE
enable createNoiseGateProcessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.15] - 2021-05-03
+## [1.1.16] - 2021-05-03
 ### Added
 - Enable createNoisegateProcessor to test if it works after modifying campus-alpha-client config to enable audioLevels and set intervals.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.15] - 2021-05-03
+### Added
+- Enable createNoisegateProcessor to test if it works after modifying campus-alpha-client config to enable audioLevels and set intervals.
+
 ## [1.1.15] - 2021-04-30
 ### Added
 - Update to @ivicos/lib-jitsi-meet version 1.0.1.

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -26,6 +26,7 @@ import { ConnectionIndicator } from '../../../connection-indicator';
 import { DisplayName } from '../../../display-name';
 import { StatusIndicators, RaisedHandIndicator, DominantSpeakerIndicator } from '../../../filmstrip';
 import { PresenceLabel } from '../../../presence-status';
+import { createNoiseGateProcessor } from '../../../stream-effects/noisegate';
 import { getCurrentLayout, LAYOUTS } from '../../../video-layout';
 import { LocalVideoMenuTriggerButton, RemoteVideoMenuTriggerButton } from '../../../video-menu';
 import {
@@ -37,7 +38,6 @@ import {
 } from '../../constants';
 import { isVideoPlayable, computeDisplayMode } from '../../functions';
 import logger from '../../logger';
-import { createNoiseGateProcessor } from '../../../stream-effects/noisegate';
 
 const JitsiTrackEvents = JitsiMeetJS.events.track;
 

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -37,8 +37,7 @@ import {
 } from '../../constants';
 import { isVideoPlayable, computeDisplayMode } from '../../functions';
 import logger from '../../logger';
-
-// import { createNoiseGateProcessor } from '../../../stream-effects/noisegate';
+import { createNoiseGateProcessor } from '../../../stream-effects/noisegate';
 
 const JitsiTrackEvents = JitsiMeetJS.events.track;
 
@@ -806,8 +805,7 @@ class Thumbnail extends Component<Props, State> {
         } = this.props;
         const { id } = _participant;
         const { audioLevel, canPlayEventReceived, volume } = this.state;
-
-        // const newVolume = createNoiseGateProcessor(audioLevel);
+        const newVolume = createNoiseGateProcessor(audioLevel);
         const styles = this._getStyles();
         const containerClassName = this._getContainerClassName();
 
@@ -858,7 +856,7 @@ class Thumbnail extends Component<Props, State> {
                         id = { `remoteAudio_${audioTrackId || ''}` }
                         muted = { _startSilent }
                         onInitialVolumeSet = { this._onInitialVolumeSet }
-                        volume = { volume } />
+                        volume = { newVolume } />
                 }
                 <div className = 'videocontainer__background' />
                 <div className = 'videocontainer__toptoolbar'>

--- a/react/features/stream-effects/noisegate/index.js
+++ b/react/features/stream-effects/noisegate/index.js
@@ -11,14 +11,8 @@ export function createNoiseGateProcessor(audioLevel: number) {
     const oldVolume: number = volume;
     let newVolume: number = 0;
 
-    console.log('VOLUME');
-    console.log(volume);
-
-    console.log('AUDIO LEVEL');
-    console.log(audioLevel);
-
     if (audioLevel <= 0.07) {
-        const reductedVolume = oldVolume - 0.1;
+        const reductedVolume = oldVolume - 0.2;
 
         if (oldVolume <= 0.1) {
             newVolume = 0;
@@ -37,11 +31,6 @@ export function createNoiseGateProcessor(audioLevel: number) {
     }
 
     volume = newVolume;
-
-    console.log('OLD VOLUME');
-    console.log(oldVolume);
-    console.log('NEW VOLUME');
-    console.log(newVolume);
 
     return newVolume;
 }


### PR DESCRIPTION
## Description of the PR

Enable createNoisegateProcessor to test if it works after modifying campus-alpha-client config to enable audioLevels and set intervals.

## Type of change

* [ ] : Technical
* [x] : Feature
* [ ] : Documentation
* [ ] : Bugfix

## Screenshots

<!-- Screenshots -->

## Checklist

- [ ] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [x] : PR ready for reviews

## Issues to clarify before merge

- [ ] Issue