### PR TITLE
disable noise gate processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.19] - 2021-05-07
+### Added
+- Disable NoiseGateProcessor due to inconsistency when more than 3 people in a meeting.
+
 ## [1.1.18] - 2021-05-05
 ### Added
 - Re-adjust Noise Gate threshold.

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -805,7 +805,8 @@ class Thumbnail extends Component<Props, State> {
         } = this.props;
         const { id } = _participant;
         const { audioLevel, canPlayEventReceived, volume } = this.state;
-        const newVolume = createNoiseGateProcessor(audioLevel);
+
+        // const newVolume = createNoiseGateProcessor(audioLevel);
         const styles = this._getStyles();
         const containerClassName = this._getContainerClassName();
 
@@ -851,7 +852,7 @@ class Thumbnail extends Component<Props, State> {
                         id = { `remoteAudio_${audioTrackId || ''}` }
                         muted = { _startSilent }
                         onInitialVolumeSet = { this._onInitialVolumeSet }
-                        volume = { newVolume } />
+                        volume = { volume } />
                 }
                 <div className = 'videocontainer__background' />
                 <div className = 'videocontainer__toptoolbar'>

--- a/react/features/filmstrip/components/web/Thumbnail.js
+++ b/react/features/filmstrip/components/web/Thumbnail.js
@@ -26,7 +26,6 @@ import { ConnectionIndicator } from '../../../connection-indicator';
 import { DisplayName } from '../../../display-name';
 import { StatusIndicators, RaisedHandIndicator, DominantSpeakerIndicator } from '../../../filmstrip';
 import { PresenceLabel } from '../../../presence-status';
-import { createNoiseGateProcessor } from '../../../stream-effects/noisegate';
 import { getCurrentLayout, LAYOUTS } from '../../../video-layout';
 import { LocalVideoMenuTriggerButton, RemoteVideoMenuTriggerButton } from '../../../video-menu';
 import {
@@ -38,6 +37,8 @@ import {
 } from '../../constants';
 import { isVideoPlayable, computeDisplayMode } from '../../functions';
 import logger from '../../logger';
+
+// import { createNoiseGateProcessor } from '../../../stream-effects/noisegate';
 
 const JitsiTrackEvents = JitsiMeetJS.events.track;
 


### PR DESCRIPTION
## Description of the PR

- Disable NoiseGateProcessor due to inconsistency when more than 3 people in a meeting.

## Type of change

* [ ] : Technical
* [ ] : Feature
* [ ] : Documentation
* [x] : Bugfix

## Screenshots

<!-- Screenshots -->

## Checklist

- [ ] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [x] : PR ready for reviews

## Issues to clarify before merge

- [ ] Issue