### PR TITLE
disabled thumbnailMenu because of inestability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.34] - 2021-03-29
+### Changed
+- Disabled thumbnailMenu because it was being displayed wrongly and causing some unstability
+
 ## [1.1.33] - 2021-03-26
 ### Updated
 - Code cleaned unneccessary comments removed and one method is renamed
@@ -14,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.31] - 2022-03-02
 ### Updated
-- Update to create a testing suite for external api; new makefile target dev-external-api and necessary bash scripts are implemented 
- 
+- Update to create a testing suite for external api; new makefile target dev-external-api and necessary bash scripts are implemented
+
 ## [1.1.30] - 2022-03-02
 ### Updated
 - Updated speaker stats and corresponding extenal api endpoints

--- a/react/features/video-menu/components/web/RemoteVideoMenuTriggerButton.js
+++ b/react/features/video-menu/components/web/RemoteVideoMenuTriggerButton.js
@@ -241,7 +241,7 @@ class RemoteVideoMenuTriggerButton extends Component<Props> {
                 onSelect = { this._onPopoverClose }
                 participant = { _participant }
                 remoteControlState = { _remoteControlState }
-                thumbnailMenu = { true } />
+                thumbnailMenu = { false } />
         );
     }
 }


### PR DESCRIPTION
## Description of the PR

Disabled thumbnailMenu because it was being displayed wrongly and causing some unstability

## Type of change

* [ ] : Technical
* [ ] : Feature
* [ ] : Documentation
* [x] : Bugfix

## Screenshots

<!-- Screenshots -->

## Checklist

- [x] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [x] : PR ready for reviews

## Issues to clarify before merge

- [ ] Issue