### PR TITLE
Prevent participants panel from opening when clicked at hand raised icon on call screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.36] - 2021-07-07
+### Changed
+- Removed onClick event from Raise Hand Icon on video call screen in order to prevent participants panel from opening
+
 ## [1.1.35] - 2021-06-17
 ### Changed
 - Added "Raise Hand" feature to the speaker stats for the virtual moderator

--- a/react/features/conference/components/web/RaisedHandsCountLabel.js
+++ b/react/features/conference/components/web/RaisedHandsCountLabel.js
@@ -1,13 +1,14 @@
 import { makeStyles } from '@material-ui/styles';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 
 import { IconRaisedHand } from '../../../base/icons';
 import { Label } from '../../../base/label';
 import { Tooltip } from '../../../base/tooltip';
 import BaseTheme from '../../../base/ui/components/BaseTheme';
-import { open as openParticipantsPane } from '../../../participants-pane/actions';
+
+// import { open as openParticipantsPane } from '../../../participants-pane/actions';
 
 const useStyles = makeStyles(theme => {
     return {
@@ -21,13 +22,15 @@ const useStyles = makeStyles(theme => {
 
 const RaisedHandsCountLabel = () => {
     const styles = useStyles();
-    const dispatch = useDispatch();
+
+    // const dispatch = useDispatch();
     const raisedHandsCount = useSelector(state =>
         (state['features/base/participants'].raisedHandsQueue || []).length);
     const { t } = useTranslation();
-    const onClick = useCallback(() => {
-        dispatch(openParticipantsPane());
-    }, []);
+
+    // const onClick = useCallback(() => {
+    //     dispatch(openParticipantsPane());
+    // }, []);
 
     return raisedHandsCount > 0 && (<Tooltip
         content = { t('raisedHandsLabel') }
@@ -37,7 +40,8 @@ const RaisedHandsCountLabel = () => {
             icon = { IconRaisedHand }
             iconColor = { BaseTheme.palette.uiBackground }
             id = 'raisedHandsCountLabel'
-            onClick = { onClick }
+
+            // onClick = { onClick }
             text = { raisedHandsCount } />
     </Tooltip>);
 };


### PR DESCRIPTION
## Description of the PR

The Hand Raised icon on video call screen is clickable, and opens the participant details panel when clicked, which is an unwanted system behaviour. With this change, the subject panel is prevented from opening when clicked on raised hand icon.

## Type of change

* [* ] : Technical
* [ ] : Feature
* [ ] : Documentation
* [ *] : Bugfix

## Checklist

- [* ] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [ *] : PR ready for reviews
