### PR TITLE
Disabled hand unraise when dominant speaker changes -CHANGELOG Update Needed Before Merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.38] - 2021-08-18
+### Changed
+- disable handunraise when dominant speaker changes
+
+## [1.1.37] - 2021-08-18
+### Changed
+- disabled notifications for raise hand
+
 ## [1.1.36] - 2021-07-07
 ### Changed
 - Removed onClick event from Raise Hand Icon on video call screen in order to prevent participants panel from opening

--- a/config.js
+++ b/config.js
@@ -170,7 +170,7 @@ var config = {
     // resolution: 720,
 
     // Specifies whether the raised hand will hide when someone becomes a dominant speaker or not
-    // disableRemoveRaisedHandOnFocus: false,
+    disableRemoveRaisedHandOnFocus: true,
 
     // Specifies whether there will be a search field in speaker stats or not
     // disableSpeakerStatsSearch: false,

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -95,14 +95,14 @@ MiddlewareRegistry.register(store => next => action => {
 
     case DOMINANT_SPEAKER_CHANGED: {
         // Lower hand through xmpp when local participant becomes dominant speaker.
-        const { id } = action.participant;
-        const state = store.getState();
-        const participant = getLocalParticipant(state);
-        const isLocal = participant && participant.id === id;
+        // const { id } = action.participant;
+        // const state = store.getState();
+        // const participant = getLocalParticipant(state);
+        // const isLocal = participant && participant.id === id;
 
-        if (isLocal && hasRaisedHand(participant) && !getDisableRemoveRaisedHandOnFocus(state)) {
-            store.dispatch(raiseHand(false));
-        }
+        // if (isLocal && hasRaisedHand(participant) && !getDisableRemoveRaisedHandOnFocus(state)) {
+        //     store.dispatch(raiseHand(false));
+        // }
 
         break;
     }

--- a/react/features/base/participants/middleware.js
+++ b/react/features/base/participants/middleware.js
@@ -14,14 +14,12 @@ import {
 } from '../../notifications';
 import { isForceMuted } from '../../participants-pane/functions';
 import { CALLING, INVITED } from '../../presence-status';
-import { RAISE_HAND_SOUND_ID } from '../../reactions/constants';
 import { APP_WILL_MOUNT, APP_WILL_UNMOUNT } from '../app';
 import {
     CONFERENCE_WILL_JOIN,
     forEachConference,
     getCurrentConference
 } from '../conference';
-import { getDisableRemoveRaisedHandOnFocus } from '../config/functions.any';
 import { JitsiConferenceEvents } from '../lib-jitsi-meet';
 import { MEDIA_TYPE } from '../media';
 import { MiddlewareRegistry, StateListenerRegistry } from '../redux';
@@ -66,7 +64,6 @@ import {
 } from './functions';
 import { PARTICIPANT_JOINED_FILE, PARTICIPANT_LEFT_FILE } from './sounds';
 
-import { hasRaisedHand, raiseHand } from '.';
 
 declare var APP: Object;
 
@@ -633,6 +630,7 @@ function _raiseHandUpdated({ dispatch, getState }, conference, participantId, ne
             uid: RAISE_HAND_NOTIFICATION_ID,
             ...action
         }, shouldDisplayAllowAction ? NOTIFICATION_TIMEOUT_TYPE.MEDIUM : NOTIFICATION_TIMEOUT_TYPE.SHORT));
+
         // dispatch(playSound(RAISE_HAND_SOUND_ID));
     }
 }

--- a/react/features/reactions/middleware.js
+++ b/react/features/reactions/middleware.js
@@ -38,7 +38,6 @@ import {
 } from './actions.any';
 import {
     ENDPOINT_REACTION_NAME,
-    RAISE_HAND_SOUND_ID,
     REACTIONS,
     REACTION_SOUND,
     SOUNDS_THRESHOLDS,
@@ -51,7 +50,6 @@ import {
     sendReactionsWebhook
 } from './functions.any';
 import logger from './logger';
-import { RAISE_HAND_SOUND_FILE } from './sounds';
 
 /**
  * Middleware which intercepts Reactions actions to handle changes to the
@@ -76,6 +74,7 @@ MiddlewareRegistry.register(store => next => action => {
                 }
             }
             );
+
             // dispatch(registerSound(RAISE_HAND_SOUND_ID, RAISE_HAND_SOUND_FILE));
         });
         break;
@@ -87,6 +86,7 @@ MiddlewareRegistry.register(store => next => action => {
                     dispatch(unregisterSound(`${REACTIONS[key].soundId}${SOUNDS_THRESHOLDS[i]}`));
                 }
             });
+
             // dispatch(unregisterSound(RAISE_HAND_SOUND_ID));
         });
         break;


### PR DESCRIPTION
## Description of the PR

The hand raise was unraised when another participant speaks or when dominant speaker changed, which is an unwanted behaviour. With this update, the hand is unraised only if the hand raise/unraise button is clicked.

[Hand unraised when someone else talks](https://www.notion.so/ivicos/Hand-unraised-when-someone-else-talks-f08978a01292439faed7b31bd513709c)

## Type of change

* [ + ] : Technical
* [ + ] : Feature
* [ ] : Documentation
* [ ] : Bugfix

## Checklist

- [ + ] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [ + ] : PR ready for reviews
