### PR TITLE
Custom youtube sharing with external api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.43] - 2022-02-15
+## [1.1.43] - 2023-02-15
 ### Changed
 - Endpoints for starting stopping video sharing are implemented
 - Endpoint for updating the shared video owner is implemented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.43] - 2022-02-15
+### Changed
+- Endpoints for starting stopping video sharing are implemented
+- Endpoint for updating the shared video owner is implemented
+- Notification of shared vido owner update to all participants is implemented
+- Speaker stats update notification is extended with video owner information
+- Automatic transfer of video ownership when the video owner leaves the call is implemented
+
 ## [1.1.42] - 2022-12-13
 ### Changed
 - Enable back the private message option inside calls

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -71,7 +71,7 @@ import { setBackgroundImage } from '../../react/features/room-background/actions
 import { isScreenAudioSupported, isScreenVideoShared } from '../../react/features/screen-share';
 import { startScreenShareFlow, startAudioScreenShareFlow } from '../../react/features/screen-share/actions';
 import { toggleScreenshotCaptureSummary } from '../../react/features/screenshot-capture';
-import { playSharedVideo, stopSharedVideo } from '../../react/features/shared-video/actions.any';
+import { playSharedVideo, stopSharedVideo, updateSharedVideoOwner } from '../../react/features/shared-video/actions.any';
 import {
     fetchDetailedSpeakerStats
 } from '../../react/features/speaker-stats/functions';
@@ -431,7 +431,7 @@ function initCommands() {
             logger.debug('Share video command received');
             sendAnalytics(createApiEvent('share.video.start'));
             console.log('!!! Update Share video command received');
-            // APP.store.dispatch(resetAndUpdateSharedVideoOwner(ownerId));
+            APP.store.dispatch(updateSharedVideoOwner(ownerId));
         },
 
         'stop-share-video': () => {

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -1665,6 +1665,19 @@ class API {
     }
 
     /**
+     * Notify external application (if API is enabled) the updated ownerId of the shared video.
+     *
+     * @param {Object} ownerId - Id of the current shared video owner
+     * @returns {void}
+     */
+    notifySharedVideoOwnerUpdated(ownerId: Object) {
+        this._sendEvent({
+            name: 'shared-video-owner-updated',
+            ownerId
+        });
+    }
+
+    /**
      * Notify external application (if API is enabled) wether the used browser is supported or not.
      *
      * @param {boolean} supported - If browser is supported or not.

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -430,7 +430,6 @@ function initCommands() {
         'update-share-video-owner': ownerId => {
             logger.debug('Share video command received');
             sendAnalytics(createApiEvent('share.video.start'));
-            console.log('!!! Update Share video command received');
             APP.store.dispatch(updateSharedVideoOwner(ownerId));
         },
 

--- a/modules/API/API.js
+++ b/modules/API/API.js
@@ -427,6 +427,13 @@ function initCommands() {
             APP.store.dispatch(playSharedVideo(url));
         },
 
+        'update-share-video-owner': ownerId => {
+            logger.debug('Share video command received');
+            sendAnalytics(createApiEvent('share.video.start'));
+            console.log('!!! Update Share video command received');
+            // APP.store.dispatch(resetAndUpdateSharedVideoOwner(ownerId));
+        },
+
         'stop-share-video': () => {
             logger.debug('Share video command received');
             sendAnalytics(createApiEvent('share.video.stop'));

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -128,6 +128,7 @@ const events = {
     'speaker-stats-collect-started': 'speakerStatsCollectStarted',
     'speaker-stats-collect-stopped': 'speakerStatsCollectStopped',
     'speaker-stats-updated': 'speakerStatsUpdated',
+    'shared-video-owner-updated' : 'sharedVideoOwnerUpdated',
     'video-ready-to-close': 'readyToClose',
     'video-conference-joined': 'videoConferenceJoined',
     'video-conference-left': 'videoConferenceLeft',
@@ -1298,8 +1299,8 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
      * @param { number } intervalRequest - Interval (ms) between each speaker stats notification.
      * @returns {void}
      */
-    startCollectSpeakerStats(intervalRequest = 1000) {
-        this.executeCommand('getSpeakerStats', true, intervalRequest);
+    startCollectSpeakerStats(intervalRequest = 1000, repeatedRequest=true) {
+        this.executeCommand('getSpeakerStats', repeatedRequest, intervalRequest);
     }
 
     /**

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -62,6 +62,7 @@ const commands = {
     setVideoQuality: 'set-video-quality',
     startRecording: 'start-recording',
     startShareVideo: 'start-share-video',
+    updateShareVideoOwner: 'update-share-video-owner',
     stopRecording: 'stop-recording',
     stopShareVideo: 'stop-share-video',
     subject: 'subject',
@@ -1331,4 +1332,34 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         this.executeCommand('setUILanguage', language);
     }
 
+    /** .........
+     * Start sharing video
+     *
+     * @param { string } videoUrl - Youtube video url parameter
+     * @returns {void}
+     */
+    startShareVideo(videoUrl) {
+        this.executeCommand('startShareVideo', videoUrl);
+    }
+
+    /** .........
+     * Update owner Id of the shared video
+     *
+     * @param { string } ownerId - Language code of the language to set.
+     * @returns {void}
+     */
+    updateShareVideoOwner(ownerId) {
+            this.executeCommand('updateShareVideoOwner', ownerId);
+    }
+
+    /** .........
+     * Stops sharing video
+     *
+     * @returns {void}
+     */
+    stopShareVideo() {
+        this.executeCommand('stopShareVideo');
+    }
+
 }
+

--- a/react/features/shared-video/actionTypes.js
+++ b/react/features/shared-video/actionTypes.js
@@ -30,3 +30,12 @@ export const RESET_SHARED_VIDEO_STATUS = 'RESET_SHARED_VIDEO_STATUS';
  * }
  */
 export const SET_DISABLE_BUTTON = 'SET_DISABLE_BUTTON';
+
+/**
+ * The type of the action which signals to update owner of the shared video
+ *
+ * {
+ *     type: UPDATE_SHARED_VIDEO_OWNER
+ * }
+ */
+export const UPDATE_SHARED_VIDEO_OWNER = 'UPDATE_SHARED_VIDEO_OWNER';

--- a/react/features/shared-video/actions.any.js
+++ b/react/features/shared-video/actions.any.js
@@ -23,10 +23,10 @@ export function resetSharedVideoStatus() {
  *
  * @param {Object} options - The options.
  * @param {boolean} options.muted - Is video muted.
- * @param {boolean} options.ownerId - Participant ID of the owner.
- * @param {boolean} options.status - Sharing status.
- * @param {boolean} options.time - Playback timestamp.
- * @param {boolean} options.videoUrl - URL of the shared video.
+ * @param {string} options.ownerId - Participant ID of the owner.
+ * @param {string} options.status - Sharing status.
+ * @param {number} options.time - Playback timestamp.
+ * @param {string} options.videoUrl - URL of the shared video.
  *
  * @returns {{
  *     type: SET_SHARED_VIDEO_STATUS,
@@ -116,6 +116,33 @@ export function toggleSharedVideo() {
             dispatch(stopSharedVideo());
         } else {
             dispatch(showSharedVideoDialog(id => dispatch(playSharedVideo(id))));
+        }
+    };
+}
+
+/**
+ *
+ * Updates a shared video ownerId.
+ *
+ * @param {string} ownerId - The new Video Owner Id for the current video.
+ *
+ * @returns {Function}
+ */
+export function updateSharedVideoOwner(ownerId) {
+    return (dispatch, getState) => {
+        const conference = getCurrentConference(getState());
+        const state = getState();
+        const currentVideoState = state['features/shared-video'];
+
+        if (conference) {
+
+            dispatch(setSharedVideoStatus({
+                videoUrl: currentVideoState.videoUrl,
+                status: currentVideoState.status,
+                time: currentVideoState.time,
+                muted: currentVideoState.muted,
+                ownerId: ownerId
+            }));
         }
     };
 }

--- a/react/features/shared-video/actions.any.js
+++ b/react/features/shared-video/actions.any.js
@@ -98,7 +98,7 @@ export function playSharedVideo(videoUrl) {
                 status: 'start',
                 time: 0,
                 ownerId: localParticipant.id,
-                previousOwnerId: localParticipant.id 
+                previousOwnerId: null 
             }));
         }
     };

--- a/react/features/shared-video/actions.any.js
+++ b/react/features/shared-video/actions.any.js
@@ -35,16 +35,18 @@ export function resetSharedVideoStatus() {
  *     status: string,
  *     time: number,
  *     videoUrl: string,
+ *     previousOwnerId: string,
  * }}
  */
-export function setSharedVideoStatus({ videoUrl, status, time, ownerId, muted }) {
+export function setSharedVideoStatus({ videoUrl, status, time, ownerId, muted, previousOwnerId }) {
     return {
         type: SET_SHARED_VIDEO_STATUS,
         ownerId,
         status,
         time,
         videoUrl,
-        muted
+        muted,
+        previousOwnerId
     };
 }
 
@@ -95,7 +97,8 @@ export function playSharedVideo(videoUrl) {
                 videoUrl,
                 status: 'start',
                 time: 0,
-                ownerId: localParticipant.id
+                ownerId: localParticipant.id,
+                previousOwnerId: localParticipant.id 
             }));
         }
     };
@@ -141,7 +144,8 @@ export function updateSharedVideoOwner(ownerId) {
                 status: currentVideoState.status,
                 time: currentVideoState.time,
                 muted: currentVideoState.muted,
-                ownerId: ownerId
+                ownerId: ownerId,
+                previousOwnerId: currentVideoState.ownerId
             }));
         }
     };

--- a/react/features/shared-video/components/web/AbstractVideoManager.js
+++ b/react/features/shared-video/components/web/AbstractVideoManager.js
@@ -13,7 +13,7 @@ import { NOTIFICATION_TIMEOUT_TYPE } from '../../../notifications';
 import { showWarningNotification } from '../../../notifications/actions';
 import { dockToolbox } from '../../../toolbox/actions.web';
 import { muteLocal } from '../../../video-menu/actions.any';
-import { setSharedVideoStatus, stopSharedVideo } from '../../actions.any';
+import { resetSharedVideoStatus, setSharedVideoStatus, stopSharedVideo } from '../../actions.any';
 import { PLAYBACK_STATUSES } from '../../constants';
 
 const logger = Logger.getLogger(__filename);
@@ -182,17 +182,27 @@ class AbstractVideoManager extends PureComponent<Props> {
 
         let timeout=null
 
+        if(hasOwnerChanged)
+            APP.API.notifySharedVideoOwnerUpdated(_ownerId);
+
         if (_isOwner) {
             if(hasOwnerChanged)
             {
-                timeout = setTimeout(()=>{this.seek(_time)}, 2000);
+                timeout = setTimeout(()=>{
+                    this.seek(_status==='start' ? 0 : _time)
+                    this.pause()
+                }, 2000);
 
                 _setSharedVideoStatus(
                     { videoUrl:_videoUrl, status:'pause', time:_time, muted:_muted, ownerId:_ownerId, previousOwnerId:_ownerId }
-                )      
-            } 
+                )
+            }
+            else if(timeout)
+                clearTimeout(timeout)
+ 
             return;
         }
+
 
         const playerTime = this.getTime();
 

--- a/react/features/shared-video/reducer.native.js
+++ b/react/features/shared-video/reducer.native.js
@@ -10,7 +10,7 @@ const initialState = {};
  * Reduces the Redux actions of the feature features/shared-video.
  */
 ReducerRegistry.register('features/shared-video', (state = initialState, action) => {
-    const { videoUrl, status, time, ownerId, muted, volume } = action;
+    const { videoUrl, status, time, ownerId, muted, volume, previousOwnerId } = action;
 
     switch (action.type) {
     case RESET_SHARED_VIDEO_STATUS:
@@ -23,7 +23,8 @@ ReducerRegistry.register('features/shared-video', (state = initialState, action)
             status,
             time,
             videoUrl,
-            volume
+            volume,
+            previousOwnerId
         };
     default:
         return state;

--- a/react/features/shared-video/reducer.web.js
+++ b/react/features/shared-video/reducer.web.js
@@ -10,7 +10,7 @@ const initialState = {};
  * Reduces the Redux actions of the feature features/shared-video.
  */
 ReducerRegistry.register('features/shared-video', (state = initialState, action) => {
-    const { videoUrl, status, time, ownerId, disabled, muted } = action;
+    const { videoUrl, status, time, ownerId, disabled, muted, previousOwnerId } = action;
 
     switch (action.type) {
     case RESET_SHARED_VIDEO_STATUS:
@@ -22,22 +22,12 @@ ReducerRegistry.register('features/shared-video', (state = initialState, action)
             ownerId,
             status,
             time,
-            videoUrl
+            videoUrl,
+            previousOwnerId
         }
-        if(initialState.ownerId!==newState.ownerId)
-            console.log('!!! Initial State', initialState);
 
-        console.log('!!! New State', newState);
         return newState;
-    // case UPDATE_SHARED_VIDEO_OWNER:
-    //     return {
-    //         ...state,
-    //         muted,
-    //         ownerId,
-    //         status,
-    //         time,
-    //         videoUrl
-    //     };
+
     case SET_DISABLE_BUTTON:
         return {
             ...state,

--- a/react/features/shared-video/reducer.web.js
+++ b/react/features/shared-video/reducer.web.js
@@ -16,15 +16,28 @@ ReducerRegistry.register('features/shared-video', (state = initialState, action)
     case RESET_SHARED_VIDEO_STATUS:
         return initialState;
     case SET_SHARED_VIDEO_STATUS:
-        return {
+        const newState = {
             ...state,
             muted,
             ownerId,
             status,
             time,
             videoUrl
-        };
+        }
+        if(initialState.ownerId!==newState.ownerId)
+            console.log('!!! Initial State', initialState);
 
+        console.log('!!! New State', newState);
+        return newState;
+    // case UPDATE_SHARED_VIDEO_OWNER:
+    //     return {
+    //         ...state,
+    //         muted,
+    //         ownerId,
+    //         status,
+    //         time,
+    //         videoUrl
+    //     };
     case SET_DISABLE_BUTTON:
         return {
             ...state,

--- a/react/features/speaker-stats/functions.js
+++ b/react/features/speaker-stats/functions.js
@@ -188,6 +188,9 @@ export function fetchDetailedSpeakerStats() {
 
     const localParticipant = state['features/base/participants'].local;
     const raisedHandsQueue = state['features/base/participants'].raisedHandsQueue;
+
+    const sharedVideoCurrentState = state['features/shared-video'];
+
     const getLocalSpeakerStats = () => {
         const stats = conference.getSpeakerStats();
 
@@ -221,6 +224,8 @@ export function fetchDetailedSpeakerStats() {
         const handRaised = raisedHandsQueue.find(item => item.id === key);
 
         localSpeakerStats[key].raisedHandTimestamp = handRaised ? handRaised.raisedHandTimestamp : 0;
+
+        localSpeakerStats[key].isSharedVideoOwner = sharedVideoCurrentState && sharedVideoCurrentState.ownerId && sharedVideoCurrentState.ownerId===key
     });
 
     APP.API.notifySpeakerStatsReceived(localSpeakerStats);


### PR DESCRIPTION
## Description of the PR

[Notion Page for Feature Request: Modify the Youtube feature in Jitsi](https://www.notion.so/ivicos/Modify-the-Youtube-feature-in-Jitsi-fbf9a4a869bd4dbfa817a0941fac522b)

- API Endpoints for starting and stopping video sharing are implemented

`api.startShareVideo('youtube_video_id')`
`api.stopShareVideo()`

- API Endpoint for updating the shared video owner is implemented

`api.updateShareVideoOwner('new_owner_id')`

- Notification of shared video owner update to all participants is implemented

```
api.addListener('sharedVideoOwnerUpdated', (e) => {
	console.log('!!!! Shared video owner update notification: ',e);
});
```
- Speaker stats update notification is extended with video owner information
- Automatic transfer of video ownership when the video owner leaves the call is implemented

## Type of change

* [x] : Technical
* [x] : Feature

## Checklist

- [x] : Changes have been tested with Firefox, Chrome
- [x] : PR ready for reviews
