### PR TITLE
Bug in getParticipantsInfo endpoint in external api is fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.46] - 2023-05-05
+### Changed
+- Bug in getParticipantsInfo endpoint in external api , which causes unreliable results is fixed.
+
 ## [1.1.45] - 2023-04-12
 ### Changed
 - Video owner update notification endpoint is extended

--- a/modules/API/external/external_api.js
+++ b/modules/API/external/external_api.js
@@ -834,11 +834,11 @@ export default class JitsiMeetExternalAPI extends EventEmitter {
         const participantIds = Object.keys(this._participants);
         const participantsInfo = Object.values(this._participants);
 
-        participantsInfo.forEach((participant, idx) => {
-            participant.participantId = participantIds[idx];
+        const participantsInfoUpdated=participantsInfo.map((participant, idx) => {
+            return {...participant, participantId:participantIds[idx]}
         });
 
-        return participantsInfo;
+        return participantsInfoUpdated;
     }
 
     /**


### PR DESCRIPTION
## Description of the PR

Bug in getParticipantsInfo endpoint in external api , which causes unreliable results is fixed.

## Type of change

 [ *] : Technical
 [ *] : Bugfix

- [ *] : Changes have been tested with Firefox, Chrome and Microsoft Edge
- [ *] : PR ready for reviews