### PR TITLE
Page including deep links to open conference in mobile app (shown in mobile browsers) is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.9] - 2024-11-20
+### Upgraded
+- Deep link promoting page shown in mobile browsers is disabled
+
 ## [2.0.8] - 2024-10-30
 ### Upgraded
 - Video sharing problem is fixed

--- a/interface_config.js
+++ b/interface_config.js
@@ -102,7 +102,7 @@ var interfaceConfig = {
      *
      * @type {boolean}
      */
-    MOBILE_APP_PROMO: true,
+    MOBILE_APP_PROMO: false,
 
     // Names of browsers which should show a warning stating the current browser
     // has a suboptimal experience. Browsers which are not listed as optimal or

--- a/react/features/base/config/reducer.ts
+++ b/react/features/base/config/reducer.ts
@@ -323,7 +323,7 @@ function _translateInterfaceConfig(oldValue: IConfig) {
         const deeplinking: IDeeplinkingConfig = {
             desktop: {} as IDeeplinkingDesktopConfig,
             hideLogo: false,
-            disabled : true,
+            disabled: true,
             android: {} as IDeeplinkingMobileConfig,
             ios: {} as IDeeplinkingMobileConfig
         };

--- a/react/features/base/config/reducer.ts
+++ b/react/features/base/config/reducer.ts
@@ -319,11 +319,11 @@ function _translateInterfaceConfig(oldValue: IConfig) {
             ? oldValue.deeplinking.disabled
             : Boolean(oldValue.disableDeepLinking);
     } else {
-        const disabled = Boolean(oldValue.disableDeepLinking);
+        // const disabled = Boolean(oldValue.disableDeepLinking);
         const deeplinking: IDeeplinkingConfig = {
             desktop: {} as IDeeplinkingDesktopConfig,
             hideLogo: false,
-            disabled,
+            disabled : true,
             android: {} as IDeeplinkingMobileConfig,
             ios: {} as IDeeplinkingMobileConfig
         };


### PR DESCRIPTION
Changing value of the parameter "deeplinking" in the config file didn't work, therefore a hardcoded change is made.
